### PR TITLE
FIX: Perform error checking on testsession/start.

### DIFF
--- a/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php
+++ b/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php
@@ -148,6 +148,20 @@ class SilverStripeContext extends MinkContext implements SilverStripeAwareContex
         $url .= '?' . http_build_query($params);
 
         $this->getSession()->visit($url);
+
+        $page = $this->getSession()->getPage();
+        $content = $page->getContent();
+
+        if(!preg_match('/<!-- +SUCCESS: +DBNAME=([^ ]+)/i', $content, $matches)) {
+            throw new \LogicException("Could not create a test session.  Details below:\n" . $content);
+
+        } else if($matches[1] != $this->databaseName) {
+            throw new \LogicException("Test session is using the database $matches[1]; it should be using $this->databaseName.");
+
+        }
+
+        $loginForm = $page->find('css', '#MemberLoginForm_LoginForm');
+
     }
 
     /**


### PR DESCRIPTION
This fix improves the robustness of the behat tests, ensuring that the testsession has actually
been successfully started before the test kicks off. Although it doesn't fix anything that
wasn't previously broken, it makes environment set-up errors a bit easier to figure out.

It looks for a new status comment in the result of testsession, that is also being added to the module.

Requires https://github.com/silverstripe-labs/silverstripe-testsession/pull/1
