### PR TITLE
Use quotes around composer require argument for some shells.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Skip this step if adding the module to an existing project.
 Switch to the newly created webroot, and add the SilverStripe Behat extension.
 
 	cd my-test-project
-	composer require silverstripe/behat-extension:*
+	composer require "silverstripe/behat-extension:*"
 
 Now get the latest Selenium2 server (requires Java):
 


### PR DESCRIPTION
The asterisk is a reserved character in some shells and will cause an error
if you don't put quotes around the argument, as it will be interpreted.

Granted we don't do this on the composer installation instructions (http://doc.silverstripe.org/framework/en/installation/composer), but
I will open a separate pull request for those docs too.
