### PR TITLE
BUG Fixing logout issues with steps

### DIFF
--- a/src/SilverStripe/BehatExtension/Context/LoginContext.php
+++ b/src/SilverStripe/BehatExtension/Context/LoginContext.php
@@ -107,7 +107,8 @@ class LoginContext extends BehatContext
      */
     public function stepIAmNotLoggedIn()
     {
-        $this->getSession()->reset();
+        $c = $this->getMainContext();
+        $this->getSession()->visit($c->joinUrlParts($c->getBaseUrl(), 'Security/logout'));
     }
 
     /**
@@ -116,8 +117,14 @@ class LoginContext extends BehatContext
     public function stepILogInWith($email, $password)
     {
         $c = $this->getMainContext();
-        $loginUrl = $c->joinUrlParts($c->getBaseUrl(), $c->getLoginUrl());
 
+        // Make sure we're logged out first, as the state of already being logged
+        // in and visiting the login page shows a warning "You don't have permission...",
+        // but in that case there is no login form.
+        $logoutUrl = $c->joinUrlParts($c->getBaseUrl(), 'Security/logout');
+        $this->getSession()->visit($logoutUrl);
+
+        $loginUrl = $c->joinUrlParts($c->getBaseUrl(), $c->getLoginUrl());
         $this->getSession()->visit($loginUrl);
 
         $page = $this->getSession()->getPage();


### PR DESCRIPTION
Firstly, stepIAmNotLoggedIn() would previously just kill the test
session, but this has the side effect of losing the current testsession
temporary database, so this causes steps of logging out to fail the
rest of the steps in a scenario.

Secondly, if we're logging a user in with stepILogInWith(), make
sure they are logged out first, otherwise "You don't have permission"
message will appear, but there is no form elements available to log
in with in this case. Logging out first by visiting Security/login
fixes this.
