### PR TITLE
Adding definition for selecting an input by the group's label.

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,10 @@ It's based on the `vendor/bin/behat -di @cms` output.
 	When /^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)" dropdown$/
 	  - Workaround for chosen.js dropdowns or tree dropdowns which hide the original dropdown field.
 
-
+	Given /^I select "([^"]*)" from "([^"]*)" input group$/
+	  - Check an individual input button from a group of inputs
+	  - Example: I select "Admins" from "Groups" input group
+	   (where "Groups" is the title of the CheckboxSetField or OptionsetField form field)
 
 ### Interactions
 

--- a/src/SilverStripe/BehatExtension/Context/BasicContext.php
+++ b/src/SilverStripe/BehatExtension/Context/BasicContext.php
@@ -392,7 +392,36 @@ JS;
         return new Step\Given(sprintf('I attach the file "%s" to "%s"', $path, $field));
     }
 
-    /**
+	/**
+	 * Select an individual input from within a group, matched by the top-most label.
+	 *
+	 * @Given /^I select "([^"]*)" from "([^"]*)" input group$/
+	 */
+	public function iSelectFromInputGroup($value, $labelText) {
+		$page = $this->getSession()->getPage();
+		$parent = null;
+
+		foreach($page->findAll('css', 'label') as $label) {
+			if($label->getText() == $labelText) {
+				$parent = $label->getParent();
+			}
+		}
+
+		if(!$parent) throw new \InvalidArgumentException(sprintf('Input group with label "%s" cannot be found', $labelText));
+
+		foreach($parent->findAll('css', 'label') as $option) {
+			if($option->getText() == $value) {
+				$for = $option->getAttribute('for');
+				$input = $parent->findById($for);
+
+				if(!$input) throw new \InvalidArgumentException(sprintf('Input "%s" cannot be found', $value));
+
+				$this->getSession()->getDriver()->click($input->getXPath());
+			}
+		}
+	}
+
+	/**
 	 * Transforms relative time statements compatible with strtotime().
 	 * Example: "time of 1 hour ago" might return "22:00:00" if its currently "23:00:00".
 	 * Customize through {@link setTimeFormat()}.


### PR DESCRIPTION
Allows for a step like: `I select "Admin" from "Groups" input group`

Adding it to BasicContext as it seems useful to be used in
other places, not just the CMS admin interface. It could be used
frontend forms that use CheckboxSetField, or OptionsetField,
for example.

Thanks to @srizzling for writing the definition for this step!
