### PR TITLE
Fix FixtureContext::prepareAsset() assuming Parent exists

### DIFF
--- a/src/SilverStripe/BehatExtension/Context/FixtureContext.php
+++ b/src/SilverStripe/BehatExtension/Context/FixtureContext.php
@@ -455,7 +455,7 @@ class FixtureContext extends BehatContext
 		}
 		$data['Filename'] = $this->joinPaths(ASSETS_DIR, $relativeTargetPath);
 		if(!isset($data['Name'])) $data['Name'] = basename($relativeTargetPath);
-		$data['ParentID'] = $parent->ID;
+		if($parent) $data['ParentID'] = $parent->ID;
 
 		$this->createdFilesPaths[] = $targetPath;
 


### PR DESCRIPTION
In some cases, we want to create an asset that doesn't have a ParentID set.
This PR allows that to happen.
