### PR TITLE
NEW: Adding some Behat steps for css selectors and Dialog confirmation

### DIFF
--- a/src/SilverStripe/BehatExtension/Context/BasicContext.php
+++ b/src/SilverStripe/BehatExtension/Context/BasicContext.php
@@ -346,6 +346,32 @@ JS;
     }
 
     /**
+     * Click on the element with the provided xpath query
+     *
+     * @When /^I click on the element with css selector "([^"]*)"$/
+     */
+    public function iClickOnTheElementWithCSSSelector($cssSelector) {
+        $session = $this->getSession();
+        $element = $session->getPage()->find(
+            'xpath',
+            $session->getSelectorsHandler()->selectorToXpath('css', $cssSelector) // just changed xpath to css
+        );
+        if (null === $element) {
+            throw new \InvalidArgumentException(sprintf('Could not evaluate CSS Selector: "%s"', $cssSelector));
+        }
+
+        $element->click();
+    }
+
+    /**
+     * @Given /^I click on the element with css selector "([^"]*)", confirming the dialog$/
+     */
+    public function iClickOnTheElementWithCSSSelectorConfirmingTheDialog($cssSelector) {
+        $this->iClickOnTheElementWithCSSSelector($cssSelector);
+        $this->iConfirmTheDialog();
+    }
+
+    /**
      * @Given /^I type "([^"]*)" into the dialog$/
      */
     public function iTypeIntoTheDialog($data)


### PR DESCRIPTION
This adds 2 new Behat steps one is to click on a element with a specific css selector (i.e. a cross to remove a option from a listbox) and the other step is a confirm Dialog wrapper for the other new step.

This is related to the following issue I have been investigating

https://github.com/silverstripe/silverstripe-cms/issues/730

The 2 new steps have been added so they can be used in a unit test which test if a alert appears when a admin tries to remove there own admin permissions.
I will be raising a pull request for framework which includes a unit test which will make use of these 2 new steps