### PR TITLE
Finds the Specfied Link in a Region

### DIFF
--- a/src/SilverStripe/BehatExtension/Context/BasicContext.php
+++ b/src/SilverStripe/BehatExtension/Context/BasicContext.php
@@ -550,4 +550,21 @@ JS;
 		assertNull($disabledAttribute, sprintf("Failed asserting field '%s' is enabled", $field));
 	}
 
+    /**
+     * Clicks a link via a configuarable css selector in the behat.yml configuration
+     * Example: Given I follow "Select" in the "" region 
+     * 
+     * @Given /^I (?:follow|click) "(?P<link>[^"]*)" in the "(?P<region>[^"]*)"(?:| region)$/
+     */
+    public function iFollowInTheRegion($link, $region) {
+        $context = $this->getMainContext();
+        $regionObj = $context->getRegionObj($region);
+        $linkObj = $regionObj->findLink($link);
+        if (empty($linkObj)) {
+            throw new \Exception(sprintf('The link "%s" was not found in the region "%s" on the page %s', $link, $region, $this->getSession()->getCurrentUrl()));
+        }
+
+        $linkObj->click();        
+    }
+
 }

--- a/src/SilverStripe/BehatExtension/Context/Initializer/SilverStripeAwareInitializer.php
+++ b/src/SilverStripe/BehatExtension/Context/Initializer/SilverStripeAwareInitializer.php
@@ -115,6 +115,7 @@ class SilverStripeAwareInitializer implements InitializerInterface
         $context->setAjaxSteps($this->ajaxSteps);
         $context->setAjaxTimeout($this->ajaxTimeout);
         $context->setScreenshotPath($this->screenshotPath);
+        $context->setRegionMap($this->regionMap);
         $context->setAdminUrl($this->adminUrl);
         $context->setLoginUrl($this->loginUrl);
     }
@@ -167,6 +168,14 @@ class SilverStripeAwareInitializer implements InitializerInterface
     public function getScreenshotPath()
     {
         return $this->screenshotPath;
+    }
+
+    public function getRegionMap(){
+        return $this->regionMap;
+    }
+
+    public function setRegionMap($regionMap) {
+        $this->regionMap = $regionMap;
     }
 
     /**

--- a/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php
+++ b/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php
@@ -120,6 +120,38 @@ class SilverStripeContext extends MinkContext implements SilverStripeAwareContex
 		return $this->screenshotPath;
 	}
 
+	public function getRegionMap(){
+		return $this->regionMap;
+	}
+
+	public function setRegionMap($regionMap){
+		$this->regionMap = $regionMap;
+	}
+
+	/**
+	 * Returns MinkElement based off region defined in .yml file
+	 * @return MinkElement|null
+	 */
+	public function getRegionObj($region) {
+		$key = $this->regionMap[$region];
+
+		if(!$this->regionMap){
+			throw new \LogicException("Cannot find 'region_map' in the behat.yml");
+		}
+		
+		if(!$key) {
+			throw new \LogicException("Cannot find the specified region in the behat.yml");
+		}
+
+		$regionObj = $this->getSession()->getPage()->find('css', $key);
+
+		if(!$regionObj) {
+			throw new ElementNotFoundException("Cannot find the specified region on the page");
+		}
+
+		return $regionObj;
+	}
+
 	/**
 	 * @BeforeScenario
 	 */

--- a/src/SilverStripe/BehatExtension/Extension.php
+++ b/src/SilverStripe/BehatExtension/Extension.php
@@ -58,6 +58,9 @@ class Extension implements ExtensionInterface
         if (isset($config['ajax_steps'])) {
             $container->setParameter('behat.silverstripe_extension.ajax_steps', $config['ajax_steps']);
         }
+        if (isset($config['region_map'])) {
+             $container->setParameter('behat.silverstripe_extension.region_map', $config['region_map']);
+        }
     }
 
     /**
@@ -84,6 +87,10 @@ class Extension implements ExtensionInterface
                 end()->
                 scalarNode('screenshot_path')->
                     defaultNull()->
+                end()->
+                arrayNode('region_map')->
+                    useAttributeAsKey('key')->
+                    prototype('variable')->end()->
                 end()->
                 scalarNode('admin_url')->
                     defaultValue('/admin/')->

--- a/src/SilverStripe/BehatExtension/services/silverstripe.yml
+++ b/src/SilverStripe/BehatExtension/services/silverstripe.yml
@@ -11,6 +11,7 @@ parameters:
   behat.silverstripe_extension.login_url: ~
   behat.silverstripe_extension.screenshot_path: ~
   behat.silverstripe_extension.module:
+  behat.silverstripe_extension.region_map: ~
   behat.silverstripe_extension.context.path_suffix: tests/behat/features/
 services:
   behat.silverstripe_extension.context.initializer:
@@ -23,6 +24,7 @@ services:
       - [setAdminUrl, [%behat.silverstripe_extension.admin_url%]]
       - [setLoginUrl, [%behat.silverstripe_extension.login_url%]]
       - [setScreenshotPath, [%behat.silverstripe_extension.screenshot_path%]]
+      - [setRegionMap, [%behat.silverstripe_extension.region_map%]]
     tags:
       - { name: behat.context.initializer }
   behat.silverstripe_extension.context.class_guesser:


### PR DESCRIPTION
This behat method will find a a specified link in a region via a configurable css selector in the behat.yml via.

For example in the behat.yml file I can define this:

```
SilverStripe\BehatExtension\Extension:
      region_map:
        Test: "[data-title=Test]"
```

Then I can use it in a test like this

```
Given I follow "Select" in the "Test" Region.
```

And it will find the button the in that Region

This PR is similar to how drupal implement it :)
