### PR TITLE
API Allow "I select the * radio button"

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,7 +514,10 @@ It's based on the `vendor/bin/behat -di @cms` output.
 	    - Selects option in select field with specified id|name|label|value.
 
 	 When /^(?:|I )additionally select "(?P<option>(?:[^"]|\\")*)" from "(?P<select>(?:[^"]|\\")*)"$/
-	    - Selects additional option in select field with specified id|name|label|value.
+		- Selects additional option in select field with specified id|name|label|value.
+
+	 When /^I select the "([^"]*)" radio button$/
+		- Selects a radio button with the given id|name|label|value
 
 	 When /^(?:|I )check "(?P<option>(?:[^"]|\\")*)"$/
 	    - Checks checkbox with specified id|name|label|value.

--- a/src/SilverStripe/BehatExtension/Context/BasicContext.php
+++ b/src/SilverStripe/BehatExtension/Context/BasicContext.php
@@ -629,4 +629,17 @@ JS;
         
     }
 
+	/**
+	 * Selects the specified radio button
+	 * 
+	 * @Given /^I select the "([^"]*)" radio button$/
+	 */
+	public function iSelectTheRadioButton($radioLabel) {
+		$session = $this->getSession();
+		$radioButton = $session->getPage()->findField($radioLabel);
+		assertNotNull($radioButton);
+		assertEquals('radio', $radioButton->getAttribute('type'));
+		$session->getDriver()->click($radioButton->getXPath());
+	}
+
 }


### PR DESCRIPTION
This is necessary since certain select behaviour, e.g. `When I check "Anchor on this page"` fail unless the operation is performed on a checkbox. This is likely due to a regression caused in a recent version of mink.
