### PR TITLE
handle single quote in getRegionObj

### DIFF
--- a/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php
+++ b/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php
@@ -137,7 +137,9 @@ class SilverStripeContext extends MinkContext implements SilverStripeAwareContex
 	 */
 	public function getRegionObj($region) {
 		// Try to find regions directly by CSS selector
-		$regionObj = $this->getSession()->getPage()->find('css', $region);
+                //handle data-title with single quote
+                $locator = str_replace("'", "\'", $region);
+                $regionObj = $this->getSession()->getPage()->find('css', $locator);
 		if($regionObj) {
 			return $regionObj;
 		}


### PR DESCRIPTION
When $region=Son's account, it fails as there is a single quote in $region
