### PR TITLE
Move selenium2 driver to ss vendor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,15 @@
         "php": ">=5.3.2",
         "phpunit/phpunit": "3.7.*",
         "behat/behat": "2.5.*@stable",
-        "behat/mink": "*@stable",
-        "behat/mink-extension": "*@stable",
-        "behat/mink-selenium2-driver": "*",
+        "behat/mink": "1.5.*@stable",
+        "behat/mink-extension": "1.3.*@stable",
+        "silverstripe/mink-selenium2-driver": "1.1.*-dev",
         "symfony/dom-crawler": "*@stable",
         "behat/mink-goutte-driver": "*",
         "silverstripe/testsession": "*",
         "silverstripe/framework": "~3.1"
     },
-
+	
     "autoload": {
         "psr-0": {
             "SilverStripe\\BehatExtension": "src/"


### PR DESCRIPTION
See https://github.com/Behat/MinkSelenium2Driver/issues/153 for the cause of this issue.

Upgrading to behat 3.0 is not impossible, but is a lot of work and necessary investment.

Downgrading to a behat 2.5 compatible version using the thirdparty vendor would require us to use 1.1.1 of mink-selenium2-driver, which is 1 year old and suffers from bugs.
