### PR TITLE
handle single quote with build-in way in getRegionObj

### DIFF
--- a/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php
+++ b/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php
@@ -137,7 +137,8 @@ class SilverStripeContext extends MinkContext implements SilverStripeAwareContex
 	 */
 	public function getRegionObj($region) {
 		// Try to find regions directly by CSS selector
-		$regionObj = $this->getSession()->getPage()->find('css', $region);
+		$regionObj = $this->getSession()->getPage()->find('css', 
+                        $this->getSession()->getSelectorsHandler()->xpathLiteral($region));
 		if($regionObj) {
 			return $regionObj;
 		}


### PR DESCRIPTION
Updated in pull request#40, with build-in method $this->getSession()->getSelectorsHandler()->xpathLiteral()
