### PR TITLE
BUG Fix call to protected method and js change event

### DIFF
--- a/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php
+++ b/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php
@@ -486,6 +486,7 @@ class SilverStripeContext extends MinkContext implements SilverStripeAwareContex
 			(function($) {
 				$("#$fieldID")
 					.val($valueEncoded)
+					.change()
 					.trigger('liszt:updated')
 					.trigger('chosen:updated');
 			})(jQuery);


### PR DESCRIPTION
Since `.val()` on hidden elements often doesn't actually register a changed event, it's sometimes necessary to explicitly force the trigger.

This also fixes the broken subsites behat tests.
