### PR TITLE
Allow setting create_temp_database to false to stop temp db creation

### DIFF
--- a/src/SilverStripe/BehatExtension/Extension.php
+++ b/src/SilverStripe/BehatExtension/Extension.php
@@ -54,6 +54,7 @@ class Extension implements ExtensionInterface
         $container->setParameter('behat.silverstripe_extension.admin_url', $config['admin_url']);
         $container->setParameter('behat.silverstripe_extension.login_url', $config['login_url']);
         $container->setParameter('behat.silverstripe_extension.screenshot_path', $config['screenshot_path']);
+        $container->setParameter('behat.silverstripe_extension.create_temp_database', $config['create_temp_database']);
         $container->setParameter('behat.silverstripe_extension.ajax_timeout', $config['ajax_timeout']);
         if (isset($config['ajax_steps'])) {
             $container->setParameter('behat.silverstripe_extension.ajax_steps', $config['ajax_steps']);
@@ -82,6 +83,9 @@ class Extension implements ExtensionInterface
     {
         $builder->
             children()->
+                scalarNode('create_temp_database')->
+                    defaultValue(true)->
+                end()->
                 scalarNode('framework_path')->
                     defaultValue('framework')->
                 end()->

--- a/src/SilverStripe/BehatExtension/services/silverstripe.yml
+++ b/src/SilverStripe/BehatExtension/services/silverstripe.yml
@@ -10,15 +10,16 @@ parameters:
   behat.silverstripe_extension.admin_url: ~
   behat.silverstripe_extension.login_url: ~
   behat.silverstripe_extension.screenshot_path: ~
+  behat.silverstripe_extension.create_temp_database: true
   behat.silverstripe_extension.module:
   behat.silverstripe_extension.region_map: ~
   behat.silverstripe_extension.context.path_suffix: tests/behat/features/
 services:
   behat.silverstripe_extension.context.initializer:
     class: %behat.silverstripe_extension.context.initializer.class%
-    arguments:
-      - %behat.silverstripe_extension.framework_path%
     calls:
+      - [setFrameworkPath, [%behat.silverstripe_extension.framework_path%]]
+      - [setCreateTempDatabase, [%behat.silverstripe_extension.create_temp_database%]]
       - [setAjaxSteps, [%behat.silverstripe_extension.ajax_steps%]]
       - [setAjaxTimeout, [%behat.silverstripe_extension.ajax_timeout%]]
       - [setAdminUrl, [%behat.silverstripe_extension.admin_url%]]


### PR DESCRIPTION
TestSessionEnvironment by default will create a temporary database for
use with behat tests, but this may not be required.

e.g. in your behat.yml:

```
default:
...

  extensions:
    ...
    SilverStripe\BehatExtension\Extension:
      create_temp_database: false
```
