### PR TITLE
Allow setting use_test_session to false to stop using testsession module

### DIFF
--- a/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php
+++ b/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php
@@ -27,6 +27,9 @@ require_once 'vendor/autoload.php';
  */
 class SilverStripeContext extends MinkContext implements SilverStripeAwareContextInterface
 {
+
+	protected $useTestSession;
+
 	protected $databaseName;
 
 	/**
@@ -74,6 +77,10 @@ class SilverStripeContext extends MinkContext implements SilverStripeAwareContex
 		// Initialize your context here
 		$this->context = $parameters;
 		$this->testSessionEnvironment = new \TestSessionEnvironment();
+	}
+
+	public function setUseTestSession($bool) {
+		$this->useTestSession = $bool;
 	}
 
 	public function setDatabase($databaseName) {
@@ -180,29 +187,31 @@ class SilverStripeContext extends MinkContext implements SilverStripeAwareContex
 	 * @BeforeScenario
 	 */
 	public function before(ScenarioEvent $event) {
-		if (!isset($this->databaseName)) {
-			throw new \LogicException(
-				'Context\'s $databaseName has to be set when implementing SilverStripeAwareContextInterface.'
-			);
-		}
+		if($this->useTestSession) {
+			if (!isset($this->databaseName)) {
+				throw new \LogicException(
+					'Context\'s $databaseName has to be set when implementing SilverStripeAwareContextInterface.'
+				);
+			}
 
-		$state = $this->getTestSessionState();
-		$this->testSessionEnvironment->startTestSession($state);
+			$state = $this->getTestSessionState();
+			$this->testSessionEnvironment->startTestSession($state);
 
-		// Optionally import database
-		if(!empty($state['importDatabasePath'])) {
-			$this->testSessionEnvironment->importDatabase(
-				$state['importDatabasePath'],
-				!empty($state['requireDefaultRecords']) ? $state['requireDefaultRecords'] : false
-			);
-		} else if(!empty($state['requireDefaultRecords']) && $state['requireDefaultRecords']) {
-			$this->testSessionEnvironment->requireDefaultRecords();
-		}
+			// Optionally import database
+			if(!empty($state['importDatabasePath'])) {
+				$this->testSessionEnvironment->importDatabase(
+					$state['importDatabasePath'],
+					!empty($state['requireDefaultRecords']) ? $state['requireDefaultRecords'] : false
+				);
+			} else if(!empty($state['requireDefaultRecords']) && $state['requireDefaultRecords']) {
+				$this->testSessionEnvironment->requireDefaultRecords();
+			}
 
-		// Fixtures
-		$fixtureFile = (!empty($params['fixture'])) ? $params['fixture'] : null;
-		if($fixtureFile) {
-			$this->testSessionEnvironment->loadFixtureIntoDb($fixtureFile);
+			// Fixtures
+			$fixtureFile = (!empty($params['fixture'])) ? $params['fixture'] : null;
+			if($fixtureFile) {
+				$this->testSessionEnvironment->loadFixtureIntoDb($fixtureFile);
+			}
 		}
 
 		if($screenSize = getenv('BEHAT_SCREEN_SIZE')) {

--- a/src/SilverStripe/BehatExtension/Extension.php
+++ b/src/SilverStripe/BehatExtension/Extension.php
@@ -54,6 +54,7 @@ class Extension implements ExtensionInterface
         $container->setParameter('behat.silverstripe_extension.admin_url', $config['admin_url']);
         $container->setParameter('behat.silverstripe_extension.login_url', $config['login_url']);
         $container->setParameter('behat.silverstripe_extension.screenshot_path', $config['screenshot_path']);
+        $container->setParameter('behat.silverstripe_extension.use_test_session', $config['use_test_session']);
         $container->setParameter('behat.silverstripe_extension.ajax_timeout', $config['ajax_timeout']);
         if (isset($config['ajax_steps'])) {
             $container->setParameter('behat.silverstripe_extension.ajax_steps', $config['ajax_steps']);
@@ -82,6 +83,9 @@ class Extension implements ExtensionInterface
     {
         $builder->
             children()->
+                scalarNode('use_test_session')->
+                    defaultValue(true)->
+                end()->
                 scalarNode('framework_path')->
                     defaultValue('framework')->
                 end()->

--- a/src/SilverStripe/BehatExtension/services/silverstripe.yml
+++ b/src/SilverStripe/BehatExtension/services/silverstripe.yml
@@ -10,15 +10,16 @@ parameters:
   behat.silverstripe_extension.admin_url: ~
   behat.silverstripe_extension.login_url: ~
   behat.silverstripe_extension.screenshot_path: ~
+  behat.silverstripe_extension.use_test_session: true
   behat.silverstripe_extension.module:
   behat.silverstripe_extension.region_map: ~
   behat.silverstripe_extension.context.path_suffix: tests/behat/features/
 services:
   behat.silverstripe_extension.context.initializer:
     class: %behat.silverstripe_extension.context.initializer.class%
-    arguments:
-      - %behat.silverstripe_extension.framework_path%
     calls:
+      - [setFrameworkPath, [%behat.silverstripe_extension.framework_path%]]
+      - [setUseTestSession, [%behat.silverstripe_extension.use_test_session%]]
       - [setAjaxSteps, [%behat.silverstripe_extension.ajax_steps%]]
       - [setAjaxTimeout, [%behat.silverstripe_extension.ajax_timeout%]]
       - [setAdminUrl, [%behat.silverstripe_extension.admin_url%]]


### PR DESCRIPTION
This means it won't create a temporary database, and this can be up to
the developer to determine the database to connect to instead.

e.g. in your behat.yml:

```
default:
...

  extensions:
    ...
    SilverStripe\BehatExtension\Extension:
      use_test_session: false
```
