### PR TITLE
More complex password default to comply with custom authenticators

### DIFF
--- a/src/SilverStripe/BehatExtension/Context/LoginContext.php
+++ b/src/SilverStripe/BehatExtension/Context/LoginContext.php
@@ -98,7 +98,8 @@ class LoginContext extends BehatContext
             $member->FirstName = $permCode;
             $member->Surname = "User";
             $member->Email = "$permCode@example.org";
-            $member->changePassword('secret');
+            $member->PasswordEncryption = "none";
+            $member->changePassword('Secret!123');
             $member->write();
             $group->Members()->add($member);
             \Member::set_password_validator($validator);
@@ -106,7 +107,7 @@ class LoginContext extends BehatContext
             $this->cache_generatedMembers[$permCode] = $member;
         }
 
-        return new Step\Given(sprintf('I log in with "%s" and "%s"', "$permCode@example.org", 'secret'));
+        return new Step\Given(sprintf('I log in with "%s" and "%s"', "$permCode@example.org", 'Secret!123'));
     }
 
     /**


### PR DESCRIPTION
Changed from 'secret' to 'Secret!123'.

For example, the CWP default configuration increases the required
complexity to include uppercase letters, see https://gitlab.cwp.govt.nz/cwp/cwp-core/blob/master/_config.php#L134
The current behaviour is that the login form simply submits to an empty page when the `cwp-core` module is installed.

This should not impact existing tests since the password is only used
indirectly, through "Given I login with ADMIN permissions".

The change also removes the password encryption to make the password a bit more obvious when devs are debugging the test databases. We already test password encryption extensively, so keeping it encrypted in Behat tests is of limited additional value IMHO.

@tractorcow @jeffreyguo Could you peer review please?