### PR TITLE
FIX getRegionObj syntax error exception

### DIFF
--- a/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php
+++ b/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php
@@ -138,11 +138,16 @@ class SilverStripeContext extends MinkContext implements SilverStripeAwareContex
 	 */
 	public function getRegionObj($region) {
 		// Try to find regions directly by CSS selector.
-		$regionObj = $this->getSession()->getPage()->find(
-			'css',
-			// Escape CSS selector
-			(false !== strpos($region, "'")) ? str_replace("'", "\'", $region) : $region
-		);
+		$regionObj = null;
+		try{
+			$regionObj = $this->getSession()->getPage()->find(
+				'css',
+				// Escape CSS selector
+				(false !== strpos($region, "'")) ? str_replace("'", "\'", $region) : $region
+			);
+		}catch(Exception $e){
+			// ignore syntax errors... we tried our best...
+		}
 		if($regionObj) {
 			return $regionObj;
 		}

--- a/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php
+++ b/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php
@@ -137,16 +137,16 @@ class SilverStripeContext extends MinkContext implements SilverStripeAwareContex
 	 * @return MinkElement|null
 	 */
 	public function getRegionObj($region) {
-		// Try to find regions directly by CSS selector.
 		$regionObj = null;
-		try{
+		$startsWithNumber = is_numeric(substr($region, 0, 1));
+		
+		// Try to find regions directly by CSS selector.
+		if(!$startsWithNumber){ // conditional, otherwise will throw a syntax error
 			$regionObj = $this->getSession()->getPage()->find(
 				'css',
 				// Escape CSS selector
 				(false !== strpos($region, "'")) ? str_replace("'", "\'", $region) : $region
 			);
-		}catch(Exception $e){
-			// ignore syntax errors... we tried our best...
 		}
 		if($regionObj) {
 			return $regionObj;


### PR DESCRIPTION
When you try to call getRegionObj with a string starting with a number, e.g. "60 NZ Minutes", the getRegionObj function will fail with a syntax exception, and not fall back to looking at the data-title attribute as designed.

Stack trace of the exception thrown:

|  #0 /var/www/public/vendor/symfony/css-selector/Symfony/Component/CssSelector/Parser/Parser.php(281): Symfony\Component\CssSelector\Exception\SyntaxErrorException::unexpectedToken('selector', Object(Symfony\Component\CssSelector\Parser\Token))
|  #1 /var/www/public/vendor/symfony/css-selector/Symfony/Component/CssSelector/Parser/Parser.php(140): Symfony\Component\CssSelector\Parser\Parser->parseSimpleSelector(Object(Symfony\Component\CssSelector\Parser\TokenStream))
|  #2 /var/www/public/vendor/symfony/css-selector/Symfony/Component/CssSelector/Parser/Parser.php(116): Symfony\Component\CssSelector\Parser\Parser->parserSelectorNode(Object(Symfony\Component\CssSelector\Parser\TokenStream))
|  #3 /var/www/public/vendor/symfony/css-selector/Symfony/Component/CssSelector/Parser/Parser.php(51): Symfony\Component\CssSelector\Parser\Parser->parseSelectorList(Object(Symfony\Component\CssSelector\Parser\TokenStream))
|  #4 /var/www/public/vendor/symfony/css-selector/Symfony/Component/CssSelector/XPath/Translator.php(299): Symfony\Component\CssSelector\Parser\Parser->parse('60 NZ Minutes')
|  #5 /var/www/public/vendor/symfony/css-selector/Symfony/Component/CssSelector/XPath/Translator.php(123): Symfony\Component\CssSelector\XPath\Translator->parseSelectors('60 NZ Minutes')
|  #6 /var/www/public/vendor/symfony/css-selector/Symfony/Component/CssSelector/CssSelector.php(65): Symfony\Component\CssSelector\XPath\Translator->cssToXPath('60 NZ Minutes', 'descendant-or-s...')
|  #7 /var/www/public/vendor/behat/mink/src/Behat/Mink/Selector/CssSelector.php(35): Symfony\Component\CssSelector\CssSelector::toXPath('60 NZ Minutes')
|  #8 /var/www/public/vendor/behat/mink/src/Behat/Mink/Selector/SelectorsHandler.php(111): Behat\Mink\Selector\CssSelector->translateToXPath('60 NZ Minutes')
|  #9 /var/www/public/vendor/behat/mink/src/Behat/Mink/Element/Element.php(159): Behat\Mink\Selector\SelectorsHandler->selectorToXpath('css', '60 NZ Minutes')
|  #10 /var/www/public/vendor/behat/mink/src/Behat/Mink/Element/Element.php(140): Behat\Mink\Element\Element->findAll('css', '60 NZ Minutes')
|  #11 /var/www/public/vendor/silverstripe/behat-extension/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php(148): Behat\Mink\Element\Element->find('css', '60 NZ Minutes')

Thanks,
Igor