### PR TITLE
update the params to be array on sending email

### DIFF
--- a/src/SilverStripe/BehatExtension/Utility/TestMailer.php
+++ b/src/SilverStripe/BehatExtension/Utility/TestMailer.php
@@ -30,8 +30,8 @@ class TestMailer extends \Mailer {
 			'Subject' => $subject,
 			'Content' => $plainContent,
 			'PlainContent' => $plainContent,
-			'AttachedFiles' => implode(',', $attachedFiles),
-			'CustomHeaders' => implode(',', $customHeaders),
+			'AttachedFiles' => $attachedFiles,
+			'CustomHeaders' => $customHeaders,
 		));
 
 		return true;
@@ -51,8 +51,8 @@ class TestMailer extends \Mailer {
 			'Subject' => $subject,
 			'Content' => $htmlContent,
 			'PlainContent' => $plainContent,
-			'AttachedFiles' => implode(',', $attachedFiles),
-			'CustomHeaders' => implode(',', $customHeaders),
+			'AttachedFiles' => $attachedFiles,
+			'CustomHeaders' => $customHeaders,
 		));
 
 		return true;


### PR DESCRIPTION
I just noticed the testmailer.php has not been updated according to the latest from SilverStripe Frramework (/framework/email/Email.php), see below lines:
https://github.com/silverstripe/silverstripe-framework/blob/3.2/email/Email.php#L84
https://github.com/silverstripe/silverstripe-framework/blob/3.2/email/Email.php#L89

Now I updated the two parameters $attachedFiles and $customHeaders to be array. Please have a check.