### PR TITLE
FIX logic error where a variable is used for two purposes

### DIFF
--- a/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php
+++ b/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php
@@ -351,9 +351,9 @@ class SilverStripeContext extends MinkContext implements SilverStripeAwareContex
 		$fields = $this->getSession()->getPage()->findAll('named', array(
 			'field', $this->getSession()->getSelectorsHandler()->xpathLiteral($field)
 		));
-		if($fields) foreach($fields as $field) {
-			if($field->isVisible()) {
-				$field->setValue($value);
+		if($fields) foreach($fields as $f) {
+			if($f->isVisible()) {
+				$f->setValue($value);
 				return;
 			}
 		}


### PR DESCRIPTION
The issue that prompted this change was that at line 361, if an exception needed to be thrown, it would be thrown with $field being a NodeElement rather than a string, causing a Catchable Fatal Error to be thrown in ElementNotFoundException::__construct#46 (can't convert object of type NodeElement to string).