### PR TITLE
Comply with moved use_test_manifest() method

### DIFF
--- a/src/SilverStripe/BehatExtension/Compiler/CoreInitializationPass.php
+++ b/src/SilverStripe/BehatExtension/Compiler/CoreInitializationPass.php
@@ -21,7 +21,14 @@ class CoreInitializationPass implements CompilerPassInterface
         $frameworkPath = $container->getParameter('behat.silverstripe_extension.framework_path');
         $_GET['flush'] = 1;
         require_once $frameworkPath . '/core/Core.php';
-        \TestRunner::use_test_manifest();
+        
+        if(class_exists('TestRunner')) {
+            // 3.x compat
+            \TestRunner::use_test_manifest();
+        } else {
+            \SapphireTest::use_test_manifest();
+        }
+
         unset($_GET['flush']);
 
         // Remove the error handler so that PHPUnit can add its own


### PR DESCRIPTION
Moved from TestRunner to SapphireTest in 4.0. 
Required for https://github.com/silverstripe/silverstripe-framework/pull/4404, but can be merged before this other PR (since it'll just fall back to using `TestRunner`). Implemented it this way to avoid creating a 3.x compat branch for Behat