### PR TITLE
FIX: params isn't defined in this context

### DIFF
--- a/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php
+++ b/src/SilverStripe/BehatExtension/Context/SilverStripeContext.php
@@ -200,7 +200,7 @@ class SilverStripeContext extends MinkContext implements SilverStripeAwareContex
 		}
 
 		// Fixtures
-		$fixtureFile = (!empty($params['fixture'])) ? $params['fixture'] : null;
+		$fixtureFile = (!empty($state['fixture'])) ? $state['fixture'] : null;
 		if($fixtureFile) {
 			$this->testSessionEnvironment->loadFixtureIntoDb($fixtureFile);
 		}


### PR DESCRIPTION
This may be carry over from PHPUnit sessions. Changing context to $state to match other env values so a default fixture can be defined through getTestSessionState.