### PR TITLE
Run shell sript to set up SilverStripe Behat test session quickly

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Switch to the newly created webroot, and add the SilverStripe Behat extension.
 	cd my-test-project
 	composer require "silverstripe/behat-extension:*"
 
+Run the following Shell script to help you setup Behat test session environment.
+
+	sh vendor/silverstripe/behat-extension/appendixes/SS-behat-quick-setup.sh
+
 Now get the latest Selenium2 server (requires Java):
 
 	wget http://selenium-release.storage.googleapis.com/2.44/selenium-server-standalone-2.44.0.jar

--- a/appendixes/SS-behat-quick-setup.sh
+++ b/appendixes/SS-behat-quick-setup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# bash script for SS behat extension setup
+
+# set output color
+red=`tput setaf 1`
+green=`tput setaf 2`
+yellow=`tput setaf 3`
+reset=`tput sgr0`
+
+# get current project directory
+path="$( pwd )"
+
+# config "base_url" in behat.yml
+echo "${green}Copying behat.yml file...${reset}"
+cp -fv $path/vendor/silverstripe/behat-extension/appendixes/behat.yml $path/behat.yml
+echo "${yellow}Please enter the site URL which you want Behat test to run against and then press ENTER: "
+read base_url
+sed -i "" "s@base_url:.*@base_url: $base_url@g" $path/behat.yml
+echo "${green}base_url: $base_url is set in your behat.yml file successfully!"
+
+# copy files for SS Behat test session running
+echo "\n${green}Copying files for SS Behat test session running...${reset}"
+
+cp -fv $path/vendor/silverstripe/behat-extension/appendixes/mysite/_config/behat.yml $path/mysite/_config/behat.yml
+echo "Appending TestSessionEnvironment and TestSessionController to $path/mysite/_config/config.yml"
+echo "\n" >> $path/mysite/_config/config.yml
+cat $path/vendor/silverstripe/behat-extension/appendixes/mysite/_config/config.yml >> $path/mysite/_config/config.yml
+cp -Rv $path/vendor/silverstripe/behat-extension/appendixes/mysite/code/testing/ $path/mysite/code/testing/
+cp -Rv $path/vendor/silverstripe/behat-extension/appendixes/mysite/tests/ $path/mysite/tests/
+echo "" > $path/mysite/tests/fixtures/FakeDatabase.json
+
+# Behat initialization, mysite is the default project name
+echo "${green}Behat initialing..."
+vendor/bin/behat --init "@mysite"
+echo "Done!"
+echo "${yellow}Please replace $path/mysite/tests/fixtures/SS-sample.sql with your own test database sql"

--- a/appendixes/behat.yml
+++ b/appendixes/behat.yml
@@ -1,0 +1,47 @@
+# Behat integration test setup (see behat.org).
+# More information about running these tests can be found under
+# https://github.com/silverstripe-labs/silverstripe-behat-extension.
+# It is safe to remove this file for normal website operation.
+default:
+  filters:
+    tags: "~@todo"
+  formatter:
+    name: pretty
+
+  extensions:
+
+    SilverStripe\BehatExtension\MinkExtension:
+      # Adjust "base_url" to your own website URL.
+      # Can be set via environment variables or _ss_environment.php/$_FILE_TO_URL_MAPPING as well.
+      base_url:  http://localhost/
+      files_path: %behat.paths.base%/framework/tests/behat/features/files/
+      default_session: selenium2
+      javascript_session: selenium2
+      selenium2:
+        browser: firefox
+
+    SilverStripe\BehatExtension\Extension:
+      screenshot_path: %behat.paths.base%/_artifacts/screenshots
+      ajax_timeout: 10000
+
+chrome:
+  filters:
+    tags: "~@todo"
+  formatter:
+    name: pretty
+
+  extensions:
+
+    SilverStripe\BehatExtension\MinkExtension:
+      # Adjust "base_url" to your own website URL.
+      # Can be set via environment variables or _ss_environment.php/$_FILE_TO_URL_MAPPING as well.
+      base_url:  http://localhost/
+      files_path: %behat.paths.base%/framework/tests/behat/features/files/
+      default_session: selenium2
+      javascript_session: selenium2
+      selenium2:
+        browser: chrome
+
+    SilverStripe\BehatExtension\Extension:
+      screenshot_path: %behat.paths.base%/_artifacts/screenshots
+      ajax_timeout: 10000

--- a/appendixes/mysite/_config/behat.yml
+++ b/appendixes/mysite/_config/behat.yml
@@ -1,0 +1,6 @@
+---
+name: behat
+---
+TestSessionEnvironment:
+  test_state_file: 'assets/TESTS_RUNNING.json'
+  test_state_id_file: 'assets/TESTS_RUNNING-%s.json'

--- a/appendixes/mysite/_config/config.yml
+++ b/appendixes/mysite/_config/config.yml
@@ -1,0 +1,9 @@
+TestSessionEnvironment:
+  extensions:
+    - FakeManagerTestSessionExtension
+  database_templates_path: mysite/tests/fixtures
+
+TestSessionController:
+  extensions:
+    - FakeManagerTestSessionExtension
+  database_templates_path: mysite/tests/fixtures

--- a/appendixes/mysite/code/testing/FakeManager.php
+++ b/appendixes/mysite/code/testing/FakeManager.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * The "Fake-Manager" instantiates fake objects, mainly to replace webservices with
+ * faked implementations. It also provides shortcuts for creating complex fake datasets
+ * through FakeDatabase.
+ *
+ * This class needs to be instantiated early in the application bootstrap process.
+ * By default that's implemented through the TestSessionExtension
+ * and config.yml.
+ *
+ * The instantiation is conditional on there being a Behat test actually running
+ * (by virtue of there being a TestSession instantiated) by a 'useFakeManager' flag
+ * set through the "TestSession" module.
+ *
+ * Since both the FeatureContext and actual application bootstrap share the same
+ * FakeDatabase persisted on disk, they can share state.
+ *
+ * In terms of mock-data, at time of writing we're using the same sources as unit-test mocks do.
+ */
+class FakeManager {
+
+    /**
+     *
+     * @var type
+     */
+    protected $db;
+
+    /**
+     *
+     * @var type
+     */
+    protected $addressRightGateway;
+
+    /**
+     *
+     * @param FakeDatabase $db
+     */
+    function __construct($db = null) {
+        $testState = Injector::inst()->get('TestSessionEnvironment')->getState();
+
+        if(!$db) {
+            $db = new FakeDatabase($testState->fakeDatabasePath);
+        }
+
+        $this->db = $db;
+    }
+
+    public function setDb($db) {
+        $this->db = $db;
+    }
+    public function getDb() {
+        return $this->db;
+    }
+}

--- a/appendixes/mysite/code/testing/FakeManagerRequestFilter.php
+++ b/appendixes/mysite/code/testing/FakeManagerRequestFilter.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Registers fake web services which are connected to a temporary database.
+ * The registration is for the lifetime of the current request only,
+ * but the database can persist beyond that, and share state with other
+ * web requests as well as Behat CLI execution.
+ *
+ * The database is reset through..TBC
+ */
+class FakeManagerRequestFilter {
+
+    public function preRequest($req, $session, $model) {
+        if(class_exists('TestSessionEnvironment')) {
+            // Set in Mysite\Test\Behaviour\FeatureContext
+            $testState = Injector::inst()->get('TestSessionEnvironment')->getState();
+
+            if($testState && isset($testState->fakeDatabasePath) && $testState->fakeDatabasePath) {
+                $fakeDb = new FakeDatabase($testState->fakeDatabasePath);
+                Injector::inst()->get('FakeManager', false, array($fakeDb));
+            }
+        }
+    }
+
+    public function postRequest() {
+    }
+}

--- a/appendixes/mysite/code/testing/FakeManagerTestSessionExtension.php
+++ b/appendixes/mysite/code/testing/FakeManagerTestSessionExtension.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Resets the fake database used for fake web services
+ * after a test scenario finishes. The database is initialized
+ * on each request.
+ */
+class FakeManagerTestSessionExtension extends Extension {
+
+    public function updateBaseFields($fields) {
+        // Don't need YAML fixtures
+        $fields->removeByname('fixture');
+    }
+
+    public function fakeDatabasePath() {
+        return TEMP_FOLDER . '/' . uniqid() . '.json';
+    }
+
+    public function templatePathRelative() {
+        return '/mysite/tests/fixtures/FakeDatabase.json';
+    }
+
+    public function updateStartForm($form) {
+        $fields = $form->Fields();
+
+        // Default to last database template
+        $templateField = $fields->dataFieldByName('importDatabasePath');
+        $templates = $templateField->getSource();
+        end($templates);
+
+        $templateField->setValue(key($templates));
+
+        $fields->push(new CheckboxField('useFakeManager', 'Use webservice fakes?', 1));
+        $fields->push(new HiddenField('fakeDatabasePath', null, $this->fakeDatabasePath()));
+        $templatePathRelative = $this->templatePathRelative();
+
+        $fields->push(
+            DropdownField::create(
+                'fakeDatabaseTemplatePath',
+                false,
+                array(
+                    BASE_PATH . $templatePathRelative => $templatePathRelative
+                )
+            )
+                ->setEmptyString('none')
+                ->setValue(BASE_PATH . $templatePathRelative)
+        );
+    }
+
+    /**
+     * This needs to handle two distinct cases:
+     * - Test Session being created by behat (calling TestSessionEnvironment directly), and
+     * - Test Session being created by browsing to dev/testsession and submitting the form.
+     *
+     * The form is modified above (@see self::updateStartForm()) and we need to ensure we respect those selections, if
+     * necessary. If it wasn't submitted via a form, then we can set the fakes up as required for behat.
+     *
+     * @param $state Array of state passed from TestSessionEnvironment
+     */
+    public function onBeforeStartTestSession(&$state) {
+        // Only set fake database paths when using fake manager
+        if(empty($state['useFakeManager'])) {
+            unset($state['fakeDatabasePath']);
+            unset($state['fakeDatabaseTemplatePath']);
+        }
+
+        if(
+            $state
+            && !empty($state['useFakeManager'])
+            && !empty($state['fakeDatabaseTemplatePath'])
+            && !empty($state['fakeDatabasePath'])
+        ) {
+            // Copy template database, to keep it clean for other runs
+            copy($state['fakeDatabaseTemplatePath'], $state['fakeDatabasePath']);
+        }
+
+        // Running via behat, so we figure out the fake stuff for ourself
+        // @see self::updateStartForm()
+        if($state && !empty($state['useFakeManager'])) {
+            $state['useFakeManager'] = 1;
+            $state['fakeDatabaseTemplatePath'] = BASE_PATH . $this->templatePathRelative();
+            if(empty($state['fakeDatabasePath'])) {
+                $state['fakeDatabasePath'] = $this->fakeDatabasePath();
+            }
+            copy($state['fakeDatabaseTemplatePath'], $state['fakeDatabasePath']);
+            chmod($state['fakeDatabasePath'], 0777);
+        }
+
+        return $state;
+    }
+
+    /**
+     * Only used for manual testing, not on Behat runs.
+     */
+    public function onBeforeClear() {
+        $testEnv = Injector::inst()->get('TestSessionEnvironment');
+        $state = $testEnv->getState();
+
+        if($state && isset($state->useFakeManager) && $state->useFakeManager) {
+            $this->resetFakeManager();
+        }
+    }
+
+    /**
+     * Only used for manual testing, not on Behat runs.
+     */
+    public function onBeforeEndTestSession() {
+        $state = $this->owner->getState();
+
+        if($state && isset($state->useFakeManager) && $state->useFakeManager) {
+            $this->resetFakeManager();
+        }
+    }
+
+    /**
+     * A similar reset is also performed in Mysite\Tests\Behaviour\FeatureContext->resetFakeDatabase().
+     * We can't reset Behat CLI runs through this measure because the CLI has a persistent connection
+     * to the underlying SQLite database file, so the browser can't remove it.
+     */
+    protected function resetFakeManager() {
+        $state = $this->owner->getState();
+
+        if($state) {
+            $manager = Injector::inst()->get(
+                'FakeManager',
+                true,
+                array(new FakeDatabase($state->fakeDatabasePath))
+            );
+            $manager->getDb()->reset();
+        }
+    }
+
+}

--- a/appendixes/mysite/tests/behat/features/bootstrap/Context/FeatureContext.php
+++ b/appendixes/mysite/tests/behat/features/bootstrap/Context/FeatureContext.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Mysite\Test\Behaviour;
+
+use SilverStripe\BehatExtension\Context\SilverStripeContext,
+    SilverStripe\BehatExtension\Context\BasicContext,
+    SilverStripe\BehatExtension\Context\LoginContext,
+    SilverStripe\BehatExtension\Context\FixtureContext,
+    SilverStripe\Framework\Test\Behaviour\CmsFormsContext,
+    SilverStripe\Framework\Test\Behaviour\CmsUiContext,
+    SilverStripe\Cms\Test\Behaviour;
+
+// PHPUnit
+require_once 'PHPUnit/Autoload.php';
+require_once 'PHPUnit/Framework/Assert/Functions.php';
+
+/**
+ * Features context
+ *
+ * Context automatically loaded by Behat.
+ * Uses subcontexts to extend functionality.
+ */
+class FeatureContext extends SilverStripeContext {
+    
+    /**
+     * @var FixtureFactory
+     */
+    protected $fixtureFactory;
+
+    /**
+     * Initializes context.
+     * Every scenario gets it's own context object.
+     *
+     * @param array $parameters context parameters (set them up through behat.yml)
+     */
+    public function __construct(array $parameters) {
+        parent::__construct($parameters);
+
+        $this->useContext('BasicContext', new BasicContext($parameters));
+        $this->useContext('LoginContext', new LoginContext($parameters));
+        $this->useContext('CmsFormsContext', new CmsFormsContext($parameters));
+        $this->useContext('CmsUiContext', new CmsUiContext($parameters));
+
+        $fixtureContext = new FixtureContext($parameters);
+        $fixtureContext->setFixtureFactory($this->getFixtureFactory());
+        $this->useContext('FixtureContext', $fixtureContext);
+
+        // Use blueprints to set user name from identifier
+        $factory = $fixtureContext->getFixtureFactory();
+        $blueprint = \Injector::inst()->create('FixtureBlueprint', 'Member');
+        $blueprint->addCallback('beforeCreate', function($identifier, &$data, &$fixtures) {
+            if(!isset($data['FirstName'])) $data['FirstName'] = $identifier;
+        });
+        $factory->define('Member', $blueprint);
+
+        // Auto-publish pages
+        if (class_exists('SiteTree')) {
+            foreach(\ClassInfo::subclassesFor('SiteTree') as $id => $class) {
+                $blueprint = \Injector::inst()->create('FixtureBlueprint', $class);
+                $blueprint->addCallback('afterCreate', function($obj, $identifier, &$data, &$fixtures) {
+                    $obj->publish('Stage', 'Live');
+                });
+                $factory->define($class, $blueprint);
+            }
+        }
+
+        $manager = \Injector::inst()->get(
+            'FakeManager',
+            true,
+            // Creates a new database automatically. Session doesn't exist here yet,
+            // so we need to take fake database path from internal config.
+            // The same path is then set in the browser session
+            // and reused across scenarios (see resetFakeDatabase()).
+            array(new \FakeDatabase($this->getFakeDatabasePath()))
+        );
+        
+        $this->manager = $manager;
+    }
+
+    public function setMinkParameters(array $parameters) {
+        parent::setMinkParameters($parameters);
+        
+        if(isset($parameters['files_path'])) {
+            $this->getSubcontext('FixtureContext')->setFilesPath($parameters['files_path']);    
+        }
+    }
+
+    /**
+     * @return FixtureFactory
+     */
+    public function getFixtureFactory() {
+        if(!$this->fixtureFactory) {
+            $this->fixtureFactory = \Injector::inst()->create('BehatFixtureFactory');
+        }
+
+        return $this->fixtureFactory;
+    }
+
+    public function setFixtureFactory(FixtureFactory $factory) {
+        $this->fixtureFactory = $factory;
+    }
+
+    /**
+     * "Shares" the database with web requests, see
+     * {@link MeridianFakeManagerControllerExtension}
+     */
+    public function getTestSessionState() {
+        return array_merge(
+            parent::getTestSessionState(),
+            array(
+                'useFakeManager' => true,
+                'importDatabasePath' => BASE_PATH .'/mysite/tests/fixtures/SS-sample.sql',
+                'requireDefaultRecords' => false,
+                'fakeDatabasePath' => $this->getFakeDatabasePath(),
+            )
+        );
+    }
+
+    public function getFakeDatabasePath() {
+        return BASE_PATH . '/FakeDatabase.json';
+    }
+    
+    /**
+     * @BeforeScenario
+     */
+    public function resetFakeDatabase() {
+        $this->manager->getDb()->reset(true);
+    }
+    //
+    // Place your definition and hook methods here:
+    //
+    //    /**
+    //     * @Given /^I have done something with "([^"]*)"$/
+    //     */
+    //    public function iHaveDoneSomethingWith($argument) {
+    //        $container = $this->kernel->getContainer();
+    //        $container->get('some_service')->doSomethingWith($argument);
+    //    }
+    //
+}

--- a/appendixes/mysite/tests/behat/features/sample.feature
+++ b/appendixes/mysite/tests/behat/features/sample.feature
@@ -1,0 +1,11 @@
+Feature: View site links
+  As a SS visitor
+  I can visit the homepage
+  So I can view SS products and services
+
+  @jira:Sample-123 @smoke @sanity
+  Scenario: Visit homepage
+    Given I am on homepage
+    Then I should see "Welcome to SilverStripe! This is the default homepage."
+    When I go to "/about-us/"
+    Then I should see "About Us"

--- a/appendixes/mysite/tests/fixtures/SS-sample.sql
+++ b/appendixes/mysite/tests/fixtures/SS-sample.sql
@@ -1,0 +1,758 @@
+# ************************************************************
+# Sequel Pro SQL dump
+# Version 4499
+#
+# http://www.sequelpro.com/
+# https://github.com/sequelpro/sequelpro
+#
+# Host: localhost (MySQL 5.6.23)
+# Database: SS_sample
+# Generation Time: 2016-02-04 21:06:03 +0000
+# ************************************************************
+
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+
+# Dump of table ErrorPage
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `ErrorPage`;
+
+CREATE TABLE `ErrorPage` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `ErrorCode` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+LOCK TABLES `ErrorPage` WRITE;
+/*!40000 ALTER TABLE `ErrorPage` DISABLE KEYS */;
+
+INSERT INTO `ErrorPage` (`ID`, `ErrorCode`)
+VALUES
+	(4,404),
+	(5,500);
+
+/*!40000 ALTER TABLE `ErrorPage` ENABLE KEYS */;
+UNLOCK TABLES;
+
+
+# Dump of table ErrorPage_Live
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `ErrorPage_Live`;
+
+CREATE TABLE `ErrorPage_Live` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `ErrorCode` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+LOCK TABLES `ErrorPage_Live` WRITE;
+/*!40000 ALTER TABLE `ErrorPage_Live` DISABLE KEYS */;
+
+INSERT INTO `ErrorPage_Live` (`ID`, `ErrorCode`)
+VALUES
+	(4,404),
+	(5,500);
+
+/*!40000 ALTER TABLE `ErrorPage_Live` ENABLE KEYS */;
+UNLOCK TABLES;
+
+
+# Dump of table ErrorPage_versions
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `ErrorPage_versions`;
+
+CREATE TABLE `ErrorPage_versions` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `RecordID` int(11) NOT NULL DEFAULT '0',
+  `Version` int(11) NOT NULL DEFAULT '0',
+  `ErrorCode` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  UNIQUE KEY `RecordID_Version` (`RecordID`,`Version`),
+  KEY `RecordID` (`RecordID`),
+  KEY `Version` (`Version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+LOCK TABLES `ErrorPage_versions` WRITE;
+/*!40000 ALTER TABLE `ErrorPage_versions` DISABLE KEYS */;
+
+INSERT INTO `ErrorPage_versions` (`ID`, `RecordID`, `Version`, `ErrorCode`)
+VALUES
+	(1,4,1,404),
+	(2,5,1,500);
+
+/*!40000 ALTER TABLE `ErrorPage_versions` ENABLE KEYS */;
+UNLOCK TABLES;
+
+
+# Dump of table File
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `File`;
+
+CREATE TABLE `File` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `ClassName` enum('File','Folder','Image','Image_Cached') DEFAULT 'File',
+  `LastEdited` datetime DEFAULT NULL,
+  `Created` datetime DEFAULT NULL,
+  `Name` varchar(255) DEFAULT NULL,
+  `Title` varchar(255) DEFAULT NULL,
+  `Filename` mediumtext,
+  `Content` mediumtext,
+  `ShowInSearch` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `ParentID` int(11) NOT NULL DEFAULT '0',
+  `OwnerID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `ParentID` (`ParentID`),
+  KEY `OwnerID` (`OwnerID`),
+  KEY `ClassName` (`ClassName`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+# Dump of table Group
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `Group`;
+
+CREATE TABLE `Group` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `ClassName` enum('Group') DEFAULT 'Group',
+  `LastEdited` datetime DEFAULT NULL,
+  `Created` datetime DEFAULT NULL,
+  `Title` varchar(255) DEFAULT NULL,
+  `Description` mediumtext,
+  `Code` varchar(255) DEFAULT NULL,
+  `Locked` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `Sort` int(11) NOT NULL DEFAULT '0',
+  `HtmlEditorConfig` mediumtext,
+  `ParentID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `ParentID` (`ParentID`),
+  KEY `ClassName` (`ClassName`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+LOCK TABLES `Group` WRITE;
+/*!40000 ALTER TABLE `Group` DISABLE KEYS */;
+
+INSERT INTO `Group` (`ID`, `ClassName`, `LastEdited`, `Created`, `Title`, `Description`, `Code`, `Locked`, `Sort`, `HtmlEditorConfig`, `ParentID`)
+VALUES
+	(1,'Group','2015-11-11 22:25:42','2015-11-11 22:25:42','Content Authors',NULL,'content-authors',0,1,NULL,0),
+	(2,'Group','2015-11-11 22:25:42','2015-11-11 22:25:42','Administrators',NULL,'administrators',0,0,NULL,0);
+
+/*!40000 ALTER TABLE `Group` ENABLE KEYS */;
+UNLOCK TABLES;
+
+
+# Dump of table Group_Members
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `Group_Members`;
+
+CREATE TABLE `Group_Members` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `GroupID` int(11) NOT NULL DEFAULT '0',
+  `MemberID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `GroupID` (`GroupID`),
+  KEY `MemberID` (`MemberID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+LOCK TABLES `Group_Members` WRITE;
+/*!40000 ALTER TABLE `Group_Members` DISABLE KEYS */;
+
+INSERT INTO `Group_Members` (`ID`, `GroupID`, `MemberID`)
+VALUES
+	(1,2,1);
+
+/*!40000 ALTER TABLE `Group_Members` ENABLE KEYS */;
+UNLOCK TABLES;
+
+
+# Dump of table Group_Roles
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `Group_Roles`;
+
+CREATE TABLE `Group_Roles` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `GroupID` int(11) NOT NULL DEFAULT '0',
+  `PermissionRoleID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `GroupID` (`GroupID`),
+  KEY `PermissionRoleID` (`PermissionRoleID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+# Dump of table LoginAttempt
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `LoginAttempt`;
+
+CREATE TABLE `LoginAttempt` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `ClassName` enum('LoginAttempt') DEFAULT 'LoginAttempt',
+  `LastEdited` datetime DEFAULT NULL,
+  `Created` datetime DEFAULT NULL,
+  `Email` varchar(255) DEFAULT NULL,
+  `Status` enum('Success','Failure') DEFAULT 'Success',
+  `IP` varchar(255) DEFAULT NULL,
+  `MemberID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `MemberID` (`MemberID`),
+  KEY `ClassName` (`ClassName`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+# Dump of table Member
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `Member`;
+
+CREATE TABLE `Member` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `ClassName` enum('Member') DEFAULT 'Member',
+  `LastEdited` datetime DEFAULT NULL,
+  `Created` datetime DEFAULT NULL,
+  `FirstName` varchar(50) DEFAULT NULL,
+  `Surname` varchar(50) DEFAULT NULL,
+  `Email` varchar(254) DEFAULT NULL,
+  `TempIDHash` varchar(160) DEFAULT NULL,
+  `TempIDExpired` datetime DEFAULT NULL,
+  `Password` varchar(160) DEFAULT NULL,
+  `RememberLoginToken` varchar(160) DEFAULT NULL,
+  `AutoLoginHash` varchar(160) DEFAULT NULL,
+  `AutoLoginExpired` datetime DEFAULT NULL,
+  `PasswordEncryption` varchar(50) DEFAULT NULL,
+  `Salt` varchar(50) DEFAULT NULL,
+  `PasswordExpiry` date DEFAULT NULL,
+  `LockedOutUntil` datetime DEFAULT NULL,
+  `Locale` varchar(6) DEFAULT NULL,
+  `FailedLoginCount` int(11) NOT NULL DEFAULT '0',
+  `DateFormat` varchar(30) DEFAULT NULL,
+  `TimeFormat` varchar(30) DEFAULT NULL,
+  PRIMARY KEY (`ID`),
+  KEY `Email` (`Email`),
+  KEY `ClassName` (`ClassName`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+LOCK TABLES `Member` WRITE;
+/*!40000 ALTER TABLE `Member` DISABLE KEYS */;
+
+INSERT INTO `Member` (`ID`, `ClassName`, `LastEdited`, `Created`, `FirstName`, `Surname`, `Email`, `TempIDHash`, `TempIDExpired`, `Password`, `RememberLoginToken`, `AutoLoginHash`, `AutoLoginExpired`, `PasswordEncryption`, `Salt`, `PasswordExpiry`, `LockedOutUntil`, `Locale`, `FailedLoginCount`, `DateFormat`, `TimeFormat`)
+VALUES
+	(1,'Member','2015-11-11 22:25:42','2015-11-11 22:25:42','Default Admin',NULL,'admin',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'en_US',0,NULL,NULL);
+
+/*!40000 ALTER TABLE `Member` ENABLE KEYS */;
+UNLOCK TABLES;
+
+
+# Dump of table MemberPassword
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `MemberPassword`;
+
+CREATE TABLE `MemberPassword` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `ClassName` enum('MemberPassword') DEFAULT 'MemberPassword',
+  `LastEdited` datetime DEFAULT NULL,
+  `Created` datetime DEFAULT NULL,
+  `Password` varchar(160) DEFAULT NULL,
+  `Salt` varchar(50) DEFAULT NULL,
+  `PasswordEncryption` varchar(50) DEFAULT NULL,
+  `MemberID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `MemberID` (`MemberID`),
+  KEY `ClassName` (`ClassName`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+# Dump of table Permission
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `Permission`;
+
+CREATE TABLE `Permission` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `ClassName` enum('Permission') DEFAULT 'Permission',
+  `LastEdited` datetime DEFAULT NULL,
+  `Created` datetime DEFAULT NULL,
+  `Code` varchar(50) DEFAULT NULL,
+  `Arg` int(11) NOT NULL DEFAULT '0',
+  `Type` int(11) NOT NULL DEFAULT '1',
+  `GroupID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `GroupID` (`GroupID`),
+  KEY `Code` (`Code`),
+  KEY `ClassName` (`ClassName`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+LOCK TABLES `Permission` WRITE;
+/*!40000 ALTER TABLE `Permission` DISABLE KEYS */;
+
+INSERT INTO `Permission` (`ID`, `ClassName`, `LastEdited`, `Created`, `Code`, `Arg`, `Type`, `GroupID`)
+VALUES
+	(1,'Permission','2015-11-11 22:25:42','2015-11-11 22:25:42','CMS_ACCESS_CMSMain',0,1,1),
+	(2,'Permission','2015-11-11 22:25:42','2015-11-11 22:25:42','CMS_ACCESS_AssetAdmin',0,1,1),
+	(3,'Permission','2015-11-11 22:25:42','2015-11-11 22:25:42','CMS_ACCESS_ReportAdmin',0,1,1),
+	(4,'Permission','2015-11-11 22:25:42','2015-11-11 22:25:42','SITETREE_REORGANISE',0,1,1),
+	(5,'Permission','2015-11-11 22:25:42','2015-11-11 22:25:42','ADMIN',0,1,2);
+
+/*!40000 ALTER TABLE `Permission` ENABLE KEYS */;
+UNLOCK TABLES;
+
+
+# Dump of table PermissionRole
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `PermissionRole`;
+
+CREATE TABLE `PermissionRole` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `ClassName` enum('PermissionRole') DEFAULT 'PermissionRole',
+  `LastEdited` datetime DEFAULT NULL,
+  `Created` datetime DEFAULT NULL,
+  `Title` varchar(50) DEFAULT NULL,
+  `OnlyAdminCanApply` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `ClassName` (`ClassName`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+# Dump of table PermissionRoleCode
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `PermissionRoleCode`;
+
+CREATE TABLE `PermissionRoleCode` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `ClassName` enum('PermissionRoleCode') DEFAULT 'PermissionRoleCode',
+  `LastEdited` datetime DEFAULT NULL,
+  `Created` datetime DEFAULT NULL,
+  `Code` varchar(50) DEFAULT NULL,
+  `RoleID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `RoleID` (`RoleID`),
+  KEY `ClassName` (`ClassName`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+# Dump of table RedirectorPage
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `RedirectorPage`;
+
+CREATE TABLE `RedirectorPage` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `RedirectionType` enum('Internal','External') DEFAULT 'Internal',
+  `ExternalURL` varchar(2083) DEFAULT NULL,
+  `LinkToID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `LinkToID` (`LinkToID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+# Dump of table RedirectorPage_Live
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `RedirectorPage_Live`;
+
+CREATE TABLE `RedirectorPage_Live` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `RedirectionType` enum('Internal','External') DEFAULT 'Internal',
+  `ExternalURL` varchar(2083) DEFAULT NULL,
+  `LinkToID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `LinkToID` (`LinkToID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+# Dump of table RedirectorPage_versions
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `RedirectorPage_versions`;
+
+CREATE TABLE `RedirectorPage_versions` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `RecordID` int(11) NOT NULL DEFAULT '0',
+  `Version` int(11) NOT NULL DEFAULT '0',
+  `RedirectionType` enum('Internal','External') DEFAULT 'Internal',
+  `ExternalURL` varchar(2083) DEFAULT NULL,
+  `LinkToID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  UNIQUE KEY `RecordID_Version` (`RecordID`,`Version`),
+  KEY `RecordID` (`RecordID`),
+  KEY `Version` (`Version`),
+  KEY `LinkToID` (`LinkToID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+# Dump of table SiteConfig
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `SiteConfig`;
+
+CREATE TABLE `SiteConfig` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `ClassName` enum('SiteConfig') DEFAULT 'SiteConfig',
+  `LastEdited` datetime DEFAULT NULL,
+  `Created` datetime DEFAULT NULL,
+  `Title` varchar(255) DEFAULT NULL,
+  `Tagline` varchar(255) DEFAULT NULL,
+  `Theme` varchar(255) DEFAULT NULL,
+  `CanViewType` enum('Anyone','LoggedInUsers','OnlyTheseUsers') DEFAULT 'Anyone',
+  `CanEditType` enum('LoggedInUsers','OnlyTheseUsers') DEFAULT 'LoggedInUsers',
+  `CanCreateTopLevelType` enum('LoggedInUsers','OnlyTheseUsers') DEFAULT 'LoggedInUsers',
+  PRIMARY KEY (`ID`),
+  KEY `ClassName` (`ClassName`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+LOCK TABLES `SiteConfig` WRITE;
+/*!40000 ALTER TABLE `SiteConfig` DISABLE KEYS */;
+
+INSERT INTO `SiteConfig` (`ID`, `ClassName`, `LastEdited`, `Created`, `Title`, `Tagline`, `Theme`, `CanViewType`, `CanEditType`, `CanCreateTopLevelType`)
+VALUES
+	(1,'SiteConfig','2015-11-11 22:25:43','2015-11-11 22:25:43','Your Site Name','your tagline here',NULL,'Anyone','LoggedInUsers','LoggedInUsers');
+
+/*!40000 ALTER TABLE `SiteConfig` ENABLE KEYS */;
+UNLOCK TABLES;
+
+
+# Dump of table SiteConfig_CreateTopLevelGroups
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `SiteConfig_CreateTopLevelGroups`;
+
+CREATE TABLE `SiteConfig_CreateTopLevelGroups` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `SiteConfigID` int(11) NOT NULL DEFAULT '0',
+  `GroupID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `SiteConfigID` (`SiteConfigID`),
+  KEY `GroupID` (`GroupID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+# Dump of table SiteConfig_EditorGroups
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `SiteConfig_EditorGroups`;
+
+CREATE TABLE `SiteConfig_EditorGroups` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `SiteConfigID` int(11) NOT NULL DEFAULT '0',
+  `GroupID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `SiteConfigID` (`SiteConfigID`),
+  KEY `GroupID` (`GroupID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+# Dump of table SiteConfig_ViewerGroups
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `SiteConfig_ViewerGroups`;
+
+CREATE TABLE `SiteConfig_ViewerGroups` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `SiteConfigID` int(11) NOT NULL DEFAULT '0',
+  `GroupID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `SiteConfigID` (`SiteConfigID`),
+  KEY `GroupID` (`GroupID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+# Dump of table SiteTree
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `SiteTree`;
+
+CREATE TABLE `SiteTree` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `ClassName` enum('SiteTree','Page','ErrorPage','RedirectorPage','VirtualPage') DEFAULT 'SiteTree',
+  `LastEdited` datetime DEFAULT NULL,
+  `Created` datetime DEFAULT NULL,
+  `URLSegment` varchar(255) DEFAULT NULL,
+  `Title` varchar(255) DEFAULT NULL,
+  `MenuTitle` varchar(100) DEFAULT NULL,
+  `Content` mediumtext,
+  `MetaDescription` mediumtext,
+  `ExtraMeta` mediumtext,
+  `ShowInMenus` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `ShowInSearch` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `Sort` int(11) NOT NULL DEFAULT '0',
+  `HasBrokenFile` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `HasBrokenLink` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `ReportClass` varchar(50) DEFAULT NULL,
+  `CanViewType` enum('Anyone','LoggedInUsers','OnlyTheseUsers','Inherit') DEFAULT 'Inherit',
+  `CanEditType` enum('LoggedInUsers','OnlyTheseUsers','Inherit') DEFAULT 'Inherit',
+  `Version` int(11) NOT NULL DEFAULT '0',
+  `ParentID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `ParentID` (`ParentID`),
+  KEY `URLSegment` (`URLSegment`),
+  KEY `ClassName` (`ClassName`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+LOCK TABLES `SiteTree` WRITE;
+/*!40000 ALTER TABLE `SiteTree` DISABLE KEYS */;
+
+INSERT INTO `SiteTree` (`ID`, `ClassName`, `LastEdited`, `Created`, `URLSegment`, `Title`, `MenuTitle`, `Content`, `MetaDescription`, `ExtraMeta`, `ShowInMenus`, `ShowInSearch`, `Sort`, `HasBrokenFile`, `HasBrokenLink`, `ReportClass`, `CanViewType`, `CanEditType`, `Version`, `ParentID`)
+VALUES
+	(1,'Page','2015-11-11 22:25:42','2015-11-11 22:25:42','home','Home',NULL,'<p>Welcome to SilverStripe! This is the default homepage. You can edit this page by opening <a href=\"admin/\">the CMS</a>. You can now access the <a href=\"http://doc.silverstripe.org\">developer documentation</a>, or begin <a href=\"http://doc.silverstripe.org/doku.php?id=tutorials\">the tutorials.</a></p>',NULL,NULL,1,1,1,0,0,NULL,'Inherit','Inherit',1,0),
+	(2,'Page','2015-11-11 22:25:42','2015-11-11 22:25:42','about-us','About Us',NULL,'<p>You can fill this page out with your own content, or delete it and create your own pages.<br></p>',NULL,NULL,1,1,2,0,0,NULL,'Inherit','Inherit',1,0),
+	(3,'Page','2015-11-11 22:25:42','2015-11-11 22:25:42','contact-us','Contact Us',NULL,'<p>You can fill this page out with your own content, or delete it and create your own pages.<br></p>',NULL,NULL,1,1,3,0,0,NULL,'Inherit','Inherit',1,0),
+	(4,'ErrorPage','2015-11-11 22:25:42','2015-11-11 22:25:42','page-not-found','Page not found',NULL,'<p>Sorry, it seems you were trying to access a page that doesn\'t exist.</p><p>Please check the spelling of the URL you were trying to access and try again.</p>',NULL,NULL,0,0,4,0,0,NULL,'Inherit','Inherit',1,0),
+	(5,'ErrorPage','2015-11-11 22:25:43','2015-11-11 22:25:43','server-error','Server error',NULL,'<p>Sorry, there was a problem with handling your request.</p>',NULL,NULL,0,0,5,0,0,NULL,'Inherit','Inherit',1,0);
+
+/*!40000 ALTER TABLE `SiteTree` ENABLE KEYS */;
+UNLOCK TABLES;
+
+
+# Dump of table SiteTree_EditorGroups
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `SiteTree_EditorGroups`;
+
+CREATE TABLE `SiteTree_EditorGroups` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `SiteTreeID` int(11) NOT NULL DEFAULT '0',
+  `GroupID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `SiteTreeID` (`SiteTreeID`),
+  KEY `GroupID` (`GroupID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+# Dump of table SiteTree_ImageTracking
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `SiteTree_ImageTracking`;
+
+CREATE TABLE `SiteTree_ImageTracking` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `SiteTreeID` int(11) NOT NULL DEFAULT '0',
+  `FileID` int(11) NOT NULL DEFAULT '0',
+  `FieldName` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`ID`),
+  KEY `SiteTreeID` (`SiteTreeID`),
+  KEY `FileID` (`FileID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+# Dump of table SiteTree_LinkTracking
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `SiteTree_LinkTracking`;
+
+CREATE TABLE `SiteTree_LinkTracking` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `SiteTreeID` int(11) NOT NULL DEFAULT '0',
+  `ChildID` int(11) NOT NULL DEFAULT '0',
+  `FieldName` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`ID`),
+  KEY `SiteTreeID` (`SiteTreeID`),
+  KEY `ChildID` (`ChildID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+# Dump of table SiteTree_Live
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `SiteTree_Live`;
+
+CREATE TABLE `SiteTree_Live` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `ClassName` enum('SiteTree','Page','ErrorPage','RedirectorPage','VirtualPage') DEFAULT 'SiteTree',
+  `LastEdited` datetime DEFAULT NULL,
+  `Created` datetime DEFAULT NULL,
+  `URLSegment` varchar(255) DEFAULT NULL,
+  `Title` varchar(255) DEFAULT NULL,
+  `MenuTitle` varchar(100) DEFAULT NULL,
+  `Content` mediumtext,
+  `MetaDescription` mediumtext,
+  `ExtraMeta` mediumtext,
+  `ShowInMenus` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `ShowInSearch` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `Sort` int(11) NOT NULL DEFAULT '0',
+  `HasBrokenFile` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `HasBrokenLink` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `ReportClass` varchar(50) DEFAULT NULL,
+  `CanViewType` enum('Anyone','LoggedInUsers','OnlyTheseUsers','Inherit') DEFAULT 'Inherit',
+  `CanEditType` enum('LoggedInUsers','OnlyTheseUsers','Inherit') DEFAULT 'Inherit',
+  `Version` int(11) NOT NULL DEFAULT '0',
+  `ParentID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `ParentID` (`ParentID`),
+  KEY `URLSegment` (`URLSegment`),
+  KEY `ClassName` (`ClassName`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+LOCK TABLES `SiteTree_Live` WRITE;
+/*!40000 ALTER TABLE `SiteTree_Live` DISABLE KEYS */;
+
+INSERT INTO `SiteTree_Live` (`ID`, `ClassName`, `LastEdited`, `Created`, `URLSegment`, `Title`, `MenuTitle`, `Content`, `MetaDescription`, `ExtraMeta`, `ShowInMenus`, `ShowInSearch`, `Sort`, `HasBrokenFile`, `HasBrokenLink`, `ReportClass`, `CanViewType`, `CanEditType`, `Version`, `ParentID`)
+VALUES
+	(1,'Page','2015-11-11 22:25:42','2015-11-11 22:25:42','home','Home',NULL,'<p>Welcome to SilverStripe! This is the default homepage. You can edit this page by opening <a href=\"admin/\">the CMS</a>. You can now access the <a href=\"http://doc.silverstripe.org\">developer documentation</a>, or begin <a href=\"http://doc.silverstripe.org/doku.php?id=tutorials\">the tutorials.</a></p>',NULL,NULL,1,1,1,0,0,NULL,'Inherit','Inherit',1,0),
+	(2,'Page','2015-11-11 22:25:42','2015-11-11 22:25:42','about-us','About Us',NULL,'<p>You can fill this page out with your own content, or delete it and create your own pages.<br></p>',NULL,NULL,1,1,2,0,0,NULL,'Inherit','Inherit',1,0),
+	(3,'Page','2015-11-11 22:25:42','2015-11-11 22:25:42','contact-us','Contact Us',NULL,'<p>You can fill this page out with your own content, or delete it and create your own pages.<br></p>',NULL,NULL,1,1,3,0,0,NULL,'Inherit','Inherit',1,0),
+	(4,'ErrorPage','2015-11-11 22:25:42','2015-11-11 22:25:42','page-not-found','Page not found',NULL,'<p>Sorry, it seems you were trying to access a page that doesn\'t exist.</p><p>Please check the spelling of the URL you were trying to access and try again.</p>',NULL,NULL,0,0,4,0,0,NULL,'Inherit','Inherit',1,0),
+	(5,'ErrorPage','2015-11-11 22:25:43','2015-11-11 22:25:43','server-error','Server error',NULL,'<p>Sorry, there was a problem with handling your request.</p>',NULL,NULL,0,0,5,0,0,NULL,'Inherit','Inherit',1,0);
+
+/*!40000 ALTER TABLE `SiteTree_Live` ENABLE KEYS */;
+UNLOCK TABLES;
+
+
+# Dump of table SiteTree_versions
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `SiteTree_versions`;
+
+CREATE TABLE `SiteTree_versions` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `RecordID` int(11) NOT NULL DEFAULT '0',
+  `Version` int(11) NOT NULL DEFAULT '0',
+  `WasPublished` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `AuthorID` int(11) NOT NULL DEFAULT '0',
+  `PublisherID` int(11) NOT NULL DEFAULT '0',
+  `ClassName` enum('SiteTree','Page','ErrorPage','RedirectorPage','VirtualPage') DEFAULT 'SiteTree',
+  `LastEdited` datetime DEFAULT NULL,
+  `Created` datetime DEFAULT NULL,
+  `URLSegment` varchar(255) DEFAULT NULL,
+  `Title` varchar(255) DEFAULT NULL,
+  `MenuTitle` varchar(100) DEFAULT NULL,
+  `Content` mediumtext,
+  `MetaDescription` mediumtext,
+  `ExtraMeta` mediumtext,
+  `ShowInMenus` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `ShowInSearch` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `Sort` int(11) NOT NULL DEFAULT '0',
+  `HasBrokenFile` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `HasBrokenLink` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `ReportClass` varchar(50) DEFAULT NULL,
+  `CanViewType` enum('Anyone','LoggedInUsers','OnlyTheseUsers','Inherit') DEFAULT 'Inherit',
+  `CanEditType` enum('LoggedInUsers','OnlyTheseUsers','Inherit') DEFAULT 'Inherit',
+  `ParentID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `RecordID_Version` (`RecordID`,`Version`),
+  KEY `RecordID` (`RecordID`),
+  KEY `Version` (`Version`),
+  KEY `AuthorID` (`AuthorID`),
+  KEY `PublisherID` (`PublisherID`),
+  KEY `ParentID` (`ParentID`),
+  KEY `URLSegment` (`URLSegment`),
+  KEY `ClassName` (`ClassName`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+LOCK TABLES `SiteTree_versions` WRITE;
+/*!40000 ALTER TABLE `SiteTree_versions` DISABLE KEYS */;
+
+INSERT INTO `SiteTree_versions` (`ID`, `RecordID`, `Version`, `WasPublished`, `AuthorID`, `PublisherID`, `ClassName`, `LastEdited`, `Created`, `URLSegment`, `Title`, `MenuTitle`, `Content`, `MetaDescription`, `ExtraMeta`, `ShowInMenus`, `ShowInSearch`, `Sort`, `HasBrokenFile`, `HasBrokenLink`, `ReportClass`, `CanViewType`, `CanEditType`, `ParentID`)
+VALUES
+	(1,1,1,1,0,0,'Page','2015-11-11 22:25:42','2015-11-11 22:25:42','home','Home',NULL,'<p>Welcome to SilverStripe! This is the default homepage. You can edit this page by opening <a href=\"admin/\">the CMS</a>. You can now access the <a href=\"http://doc.silverstripe.org\">developer documentation</a>, or begin <a href=\"http://doc.silverstripe.org/doku.php?id=tutorials\">the tutorials.</a></p>',NULL,NULL,1,1,1,0,0,NULL,'Inherit','Inherit',0),
+	(2,2,1,1,0,0,'Page','2015-11-11 22:25:42','2015-11-11 22:25:42','about-us','About Us',NULL,'<p>You can fill this page out with your own content, or delete it and create your own pages.<br></p>',NULL,NULL,1,1,2,0,0,NULL,'Inherit','Inherit',0),
+	(3,3,1,1,0,0,'Page','2015-11-11 22:25:42','2015-11-11 22:25:42','contact-us','Contact Us',NULL,'<p>You can fill this page out with your own content, or delete it and create your own pages.<br></p>',NULL,NULL,1,1,3,0,0,NULL,'Inherit','Inherit',0),
+	(4,4,1,1,0,0,'ErrorPage','2015-11-11 22:25:42','2015-11-11 22:25:42','page-not-found','Page not found',NULL,'<p>Sorry, it seems you were trying to access a page that doesn\'t exist.</p><p>Please check the spelling of the URL you were trying to access and try again.</p>',NULL,NULL,0,0,4,0,0,NULL,'Inherit','Inherit',0),
+	(5,5,1,1,0,0,'ErrorPage','2015-11-11 22:25:43','2015-11-11 22:25:43','server-error','Server error',NULL,'<p>Sorry, there was a problem with handling your request.</p>',NULL,NULL,0,0,5,0,0,NULL,'Inherit','Inherit',0);
+
+/*!40000 ALTER TABLE `SiteTree_versions` ENABLE KEYS */;
+UNLOCK TABLES;
+
+
+# Dump of table SiteTree_ViewerGroups
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `SiteTree_ViewerGroups`;
+
+CREATE TABLE `SiteTree_ViewerGroups` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `SiteTreeID` int(11) NOT NULL DEFAULT '0',
+  `GroupID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `SiteTreeID` (`SiteTreeID`),
+  KEY `GroupID` (`GroupID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+# Dump of table VirtualPage
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `VirtualPage`;
+
+CREATE TABLE `VirtualPage` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `VersionID` int(11) NOT NULL DEFAULT '0',
+  `CopyContentFromID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `CopyContentFromID` (`CopyContentFromID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+# Dump of table VirtualPage_Live
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `VirtualPage_Live`;
+
+CREATE TABLE `VirtualPage_Live` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `VersionID` int(11) NOT NULL DEFAULT '0',
+  `CopyContentFromID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  KEY `CopyContentFromID` (`CopyContentFromID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+# Dump of table VirtualPage_versions
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `VirtualPage_versions`;
+
+CREATE TABLE `VirtualPage_versions` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `RecordID` int(11) NOT NULL DEFAULT '0',
+  `Version` int(11) NOT NULL DEFAULT '0',
+  `VersionID` int(11) NOT NULL DEFAULT '0',
+  `CopyContentFromID` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`),
+  UNIQUE KEY `RecordID_Version` (`RecordID`,`Version`),
+  KEY `RecordID` (`RecordID`),
+  KEY `Version` (`Version`),
+  KEY `CopyContentFromID` (`CopyContentFromID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
 		"symfony/yaml": "~2.0",
 		"symfony/finder": "~2.0",
 		"silverstripe/testsession": "*",
-		"silverstripe/framework": "^4.0.0"
+		"silverstripe/framework": "^4.0.0",
+		"chillu/fakedatabase": "*"
 	},
 
 	"autoload": {


### PR DESCRIPTION
We have SilverStripe Behat extension and test session, but it's not easy to set up a Behat test session. We need to do lots of settings and configuration after run composer install for these two packages. Here I  created a shell script to do the settings and configurations automatically.
`$ sh vendor/silverstripe/behat-extension/appendixes/SS-behat-quick-setup.sh`
NOTE: suppose "silverstripe/behat-extension" is composer installed.