### PR TITLE
BUG Avoid trying to get singletons fon non-existan classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,23 +7,16 @@ sudo: false
 cache:
   directories:
     - $HOME/.composer/cache/files
-
-php:
- - 5.6
-
-env:
-  matrix:
-    - PHPUNIT_TEST=1
-    - PHPCS_TEST=1
-
 matrix:
   include:
-    - php: 5.6
+    - php: 7.1
       env: PHPUNIT_TEST=1
-    - php: 7.0
+    - php: 7.2
       env: PHPUNIT_TEST=1
-    - php: 7.1.2
-      env: PHPUNIT_TEST=1
+    - php: 7.3
+      env: PHPUNIT_TEST=1 PHPCS_TEST=1
+
+
 
 before_script:
   - export PATH=~/.composer/vendor/bin:$PATH

--- a/src/Context/FixtureContext.php
+++ b/src/Context/FixtureContext.php
@@ -897,13 +897,13 @@ YAML;
 
         // Try direct mapping
         $class = str_replace(' ', '', ucwords($type));
-        if (class_exists($class) && is_subclass_of($class, 'SilverStripe\\ORM\\DataObject')) {
+        if (class_exists($class) && is_subclass_of($class, DataObject::class)) {
             return ClassInfo::class_name($class);
         }
 
         // Fall back to singular names
-        foreach (array_values(ClassInfo::subclassesFor('SilverStripe\\ORM\\DataObject')) as $candidate) {
-            if (strcasecmp(singleton($candidate)->singular_name(), $type) === 0) {
+        foreach (array_values(ClassInfo::subclassesFor(DataObject::class)) as $candidate) {
+            if (class_exists($candidate) && strcasecmp(singleton($candidate)->singular_name(), $type) === 0) {
                 return $candidate;
             }
         }


### PR DESCRIPTION
This PR is meant to bypass this bug: https://github.com/silverstripe/silverstripe-framework/issues/9500

Ideally, we would fix the underlying issue, but that might not be trivial and this issue is preventing some behat builds from going green in the short term.