### PR TITLE
NEW add iClickOnTheElementConfirmingTheDialog

### DIFF
--- a/src/Context/BasicContext.php
+++ b/src/Context/BasicContext.php
@@ -500,6 +500,18 @@ JS;
     }
 
     /**
+     * Needs to be in single command to avoid "unexpected alert open" errors in Selenium.
+     *
+     * @When /^I click on the "([^"]+)" element, confirming the dialog$/
+     * @param $selector
+     */
+    public function iClickOnTheElementConfirmingTheDialog($selector)
+    {
+        $this->iClickOnTheElement($selector);
+        $this->iConfirmTheDialog();
+    }
+
+    /**
      * @Given /^I (click|double click) "([^"]*)" in the "([^"]*)" element$/
      * @param string $clickType
      * @param string $text


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-behat-extension/issues/200

Makes sense to include this as well while we're doing this.  This was in silverstripe-cms.  There are a few other 'confirming the dialog' functions in BasicContext

Tag 4.4.0 after merge