### PR TITLE
DEP Set PHP 7.4 as the minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3",
         "behat/behat": "^3.9",


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10219
