### PR TITLE
FIX Use usleep for fractions of a second

### DIFF
--- a/src/Context/LoginContext.php
+++ b/src/Context/LoginContext.php
@@ -104,8 +104,8 @@ class LoginContext implements Context
             if ($btn->getText() !== 'Setup later') {
                 continue;
             }
-            // There's been issues clicking the button, so try waiting for a little bit
-            sleep(0.3);
+            // There's been issues clicking the button, so try waiting for 0.3 seconds
+            usleep(0.3 * 1000000);
             $btn->click();
             $clicked = true;
             break;

--- a/src/Context/SilverStripeContext.php
+++ b/src/Context/SilverStripeContext.php
@@ -510,7 +510,7 @@ abstract class SilverStripeContext extends MinkContext implements SilverStripeAw
         }
 
         $state = $this->testSessionEnvironment->getState();
-        $oldDatetime = \DateTime::createFromFormat('Y-m-d H:i:s', isset($state->datetime) ? $state->datetime : null);
+        $oldDatetime = \DateTime::createFromFormat('Y-m-d H:i:s', $state->datetime ?? '');
         if ($oldDatetime) {
             $newDatetime->setTime($oldDatetime->format('H'), $oldDatetime->format('i'), $oldDatetime->format('s'));
         }


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/37

Fix https://github.com/silverstripe/silverstripe-totp-authenticator/runs/7492246731?check_suite_focus=true#step:12:230
`       8192: Implicit conversion from float 0.3 to int loses precision in vendor/silverstripe/behat-extension/src/Context/LoginContext.php line 108`

Fix https://github.com/silverstripe/silverstripe-versioned-admin/runs/7492250060?check_suite_focus=true#step:12:226
`       8192: DateTime::createFromFormat(): Passing null to parameter #2 ($datetime) of type string is deprecated in vendor/silverstripe/behat-extension/src/Context/SilverStripeContext.php line 513`