### PR TITLE
DEP Require symfony ^6.1 and friends-of-behat/mink-extension fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,12 +26,12 @@
         "squizlabs/php_codesniffer": "^3.7",
         "behat/behat": "^3.11.0",
         "behat/mink": "^1.10.0",
-        "behat/mink-extension": "^2.3.1",
+        "friends-of-behat/mink-extension": "^2",
         "silverstripe/mink-facebook-web-driver": "^2",
-        "symfony/dom-crawler": "^4.4.44",
+        "symfony/dom-crawler": "^6.1",
         "silverstripe/testsession": "^3",
         "silverstripe/framework": "^5",
-        "symfony/finder": "^4.4.44"
+        "symfony/finder": "^6.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10389

~~Requires that https://github.com/silverstripe/MinkExtension/pull/1 is merged first, has been given a 2.3.2 tag and packagist for silverstripe/mink-extension is functioning~~

^ Has been superseded by the friends-of-behat/mink-extension fork