### PR TITLE
BUG Correct method parameters on stepCreateRecordWithTable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,3 +9,5 @@ jobs:
   ci:
     name: CI
     uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
+    with:
+      composer_require_extra: silverstripe/installer:4.13.x-dev

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ use the inline definition syntax. The following example shows some syntax variat
 		Scenario: View a page in the tree
 			Given I am logged in with "ADMIN" permissions
 			And I go to "/admin/pages"
-			Then I should see "Page 1" in CMS Tree
+			Then I should see "Page 1"
 
  * Fixtures are created where you defined them. If you want the fixtures to be created
    before every scenario, define them in 

--- a/src/Context/FixtureContext.php
+++ b/src/Context/FixtureContext.php
@@ -289,22 +289,23 @@ class FixtureContext implements Context
      * @param string $null
      * @param TableNode $fieldsTable
      */
-    public function stepCreateRecordWithTable($type, $id, $null, TableNode $fieldsTable)
+    public function stepCreateRecordWithTable($type, $id, TableNode $fieldsTable)
     {
+
         $class = $this->convertTypeToClass($type);
         // TODO Support more than one record
         $fields = $this->convertFields($class, $fieldsTable->getRowsHash());
         $fields = $this->prepareFixture($class, $id, $fields);
 
         // We should check if this fixture object already exists - if it does, we update it. If not, we create it
-        if ($existingFixture = $this->fixtureFactory->get($class, $id)) {
+        if ($existingFixture = $this->getFixtureFactory()->get($class, $id)) {
             // Merge existing data with new data, and create new object to replace existing object
             foreach ($fields as $k => $v) {
                 $existingFixture->$k = $v;
             }
             $existingFixture->write();
         } else {
-            $this->fixtureFactory->createObject($class, $id, $fields);
+            $this->getFixtureFactory()->createObject($class, $id, $fields);
         }
     }
 


### PR DESCRIPTION
`$null` parameter doesn't appear to be ever added to the method. `$this->fixtureFactory` is null also.

Requires [this PR](https://github.com/silverstripe/gha-generate-matrix/pull/57) to be merged and released first, then re-run CI 

## Parent issue
- https://github.com/silverstripe/silverstripe-behat-extension/issues/224