### PR TITLE
FIX Emails are arrays in TestMailer

### DIFF
--- a/src/Context/EmailContext.php
+++ b/src/Context/EmailContext.php
@@ -89,7 +89,7 @@ class EmailContext implements Context
         $match = $this->mailer->findEmail($to, $from, $subject);
         $allMails = $this->mailer->findEmails($to, $from);
         $allTitles = $allMails ? '"' . implode('","', array_map(function ($email) {
-            return $email->Subject;
+            return $email['Subject'];
         }, $allMails)) . '"' : null;
         if (trim($negate ?? '')) {
             Assert::assertNull($match);
@@ -174,7 +174,7 @@ class EmailContext implements Context
         $match = $this->mailer->findEmail($to, $from);
         Assert::assertNotNull($match);
 
-        $crawler = new Crawler($match->Content);
+        $crawler = new Crawler($match['Content']);
         $linkEl = $crawler->selectLink($linkSelector);
         Assert::assertNotNull($linkEl);
         $link = $linkEl->attr('href');
@@ -197,7 +197,7 @@ class EmailContext implements Context
         $match = $this->mailer->findEmail($to, $from, $title);
         Assert::assertNotNull($match);
 
-        $crawler = new Crawler($match->Content);
+        $crawler = new Crawler($match['Content']);
         $linkEl = $crawler->selectLink($linkSelector);
         Assert::assertNotNull($linkEl);
         $link = $linkEl->attr('href');
@@ -283,7 +283,7 @@ class EmailContext implements Context
      */
     public function thereIsAnEmailTitled($negate, $subject)
     {
-        $match = $this->mailer->findEmail(null, null, $subject);
+        $match = $this->mailer->findEmail('', null, $subject);
         if (trim($negate ?? '')) {
             Assert::assertNull($match);
         } else {

--- a/src/Utility/TestMailer.php
+++ b/src/Utility/TestMailer.php
@@ -65,9 +65,10 @@ class TestMailer extends BaseTestMailer
         ?string $content = null
     ): ?array {
         $matches = $this->findEmails($to, $from, $subject, $content);
-                //got the count of matches emails
-                $emailCount = count($matches ?? []);
-                //get the last(latest) one
+        //got the count of matches emails
+        $emailCount = count($matches ?? []);
+        //get the last(latest) one
+
         return $matches ? $matches[$emailCount-1] : null;
     }
 
@@ -108,14 +109,14 @@ class TestMailer extends BaseTestMailer
                 }
             }
             if ($matched) {
-                $matches[] = $email;
+                $matches[] = json_decode(json_encode($email), true);
             }
         }
 
         return $matches;
     }
 
-    protected function saveEmail($data)
+    protected function saveEmail(array $data)
     {
         $state = $this->testSessionEnvironment->getState();
         if (!isset($state->emails)) {


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-installer/actions/runs/3285991111/jobs/5499431854 and https://github.com/silverstripe/silverstripe-admin/actions/runs/3316905244/jobs/5499433811

> `SilverStripe\BehatExtension\Context\EmailContext::thereIsAnEmailFromToTitled()`
Type error: `SilverStripe\BehatExtension\Utility\TestMailer::findEmail()`: Return value must be of type ?array, stdClass returned (Behat\Testwork\Call\Exception\FatalThrowableError)

## Notes
Rerun the broken builds in admin and installer after merging this PR

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/611