### PR TITLE
DOC Fix typo in README to use correct prop for URLSegment

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,7 +633,7 @@ It's based on the `vendor/bin/behat -di @cms` output.
 	    - Example: Given a "page" "Page 1"
 
 	Given /^(?:(an|a|the) )"(?<type>[^"]+)" "(?<id>[^"]+)" with (?<data>.*)$/
-	    - Example: Given a "page" "Page 1" with "URL"="page-1" and "Content"="my page 1"
+	    - Example: Given a "page" "Page 1" with "URLSegment"="page-1" and "Content"="my page 1"
 
 	Given /^(?:(an|a|the) )"(?<type>[^"]+)" "(?<id>[^"]+)" has the following data$/
 	    - Example: And the "page" "Page 2" has the following data


### PR DESCRIPTION
FIx a typo in the readme

## Parent issue
- https://github.com/silverstripe/silverstripe-behat-extension/issues/245