### PR TITLE
MNT Remove composer_require_extra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,5 +9,3 @@ jobs:
   ci:
     name: CI
     uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
-    with:
-      composer_require_extra: silverstripe/installer:4.13.x-dev


### PR DESCRIPTION
Issue https://github.com/silverstripe/recipe-kitchen-sink/issues/44

Causing the `5` build to fail after this was previously merged up because it cannot install, no idea why we have this requirement here, if it doesn't install property then should fix in composer.json
