### PR TITLE
ENH Migrate image selection logic from asset-admin

### DIFF
--- a/src/Context/FixtureContext.php
+++ b/src/Context/FixtureContext.php
@@ -886,6 +886,70 @@ YAML;
     }
 
     /**
+     * Selects the first match of $select in the given HTML editor (tinymce)
+     */
+    protected function selectInTheHtmlField(string $select, string $field)
+    {
+        $inputField = $this->getHtmlField($field);
+        $inputField->getParent()->find('css', 'iframe')->click();
+        $inputFieldId = $inputField->getAttribute('id');
+        $js = <<<JS
+        var editor = jQuery('#$inputFieldId').entwine('ss').getEditor(),
+            doc = editor.getInstance().getDoc(),
+            sel = doc.getSelection(),
+            rng = new Range(),
+            matched = false;
+
+        jQuery(doc).find("$select").each(function() {
+            if(!matched) {
+                rng.selectNode(this);
+                sel.removeAllRanges();
+                sel.addRange(rng);
+                matched = true;
+            }
+        });
+        JS;
+        $this->getMainContext()->getSession()->executeScript($js);
+    }
+
+    /**
+     * Selects the first image match in the HTML editor (tinymce)
+     *
+     * @When /^I select the image "([^"]+)" in the "([^"]+)" HTML field$/
+     * @param string $filename
+     * @param string $field
+     */
+    public function iSelectTheImageInHtmlField($filename, $field)
+    {
+        $this->selectInTheHtmlField("img[src*='$filename']", $field);
+    }
+
+    /**
+     * Locate an HTML editor field
+     *
+     * @param string $locator Raw html field identifier as passed from
+     * @return NodeElement
+     */
+    protected function getHtmlField($locator)
+    {
+        $locator = str_replace('\\"', '"', $locator ?? '');
+        $page = $this->getMainContext()->getSession()->getPage();
+        $element = $page->find('css', 'textarea.htmleditor[name=\'' . $locator . '\']');
+        if ($element) {
+            return $element;
+        }
+        $label = $page->findAll('xpath', sprintf('//label[contains(text(), \'%s\')]', $locator));
+        if (!empty($label)) {
+            Assert::assertCount(1, $label, "Found more than one element containing the phrase \"$locator\"");
+            $label = array_shift($label);
+            $fieldId = $label->getAttribute('for');
+            $element = $page->find('css', '#' . $fieldId);
+        }
+        Assert::assertNotNull($element, sprintf('HTML field "%s" not found', $locator));
+        return $element;
+    }
+
+    /**
      * Converts a natural language class description to an actual class name.
      * Respects {@link DataObject::$singular_name} variations.
      * Example: "redirector page" -> "RedirectorPage"


### PR DESCRIPTION
Migrates logic for selecting an image in the TinyMCE WYSIWYG from silverstripe/asset-admin as it's now needed in silverstripe/cms as well.

Make sure you check the installer CI run linked in the issue to see behat passing happily

## Required for
- https://github.com/silverstripe/silverstripe-asset-admin/pull/1397
- https://github.com/silverstripe/silverstripe-cms/pull/2883

## Issue
- https://github.com/silverstripe/silverstripe-admin/issues/1548