### PR TITLE
correct required type for findEmail() $to

### DIFF
--- a/src/Context/EmailContext.php
+++ b/src/Context/EmailContext.php
@@ -64,7 +64,7 @@ class EmailContext implements Context
      */
     public function thereIsAnEmailFromTo($negate, $direction, $email)
     {
-        $to = ($direction == 'to') ? $email : null;
+        $to = ($direction == 'to') ? $email : '';
         $from = ($direction == 'from') ? $email : null;
         $match = $this->mailer->findEmail($to, $from);
         if (trim($negate ?? '')) {
@@ -84,7 +84,7 @@ class EmailContext implements Context
      */
     public function thereIsAnEmailFromToTitled($negate, $direction, $email, $subject)
     {
-        $to = ($direction == 'to') ? $email : null;
+        $to = ($direction == 'to') ? $email : '';
         $from = ($direction == 'from') ? $email : null;
         $match = $this->mailer->findEmail($to, $from, $subject);
         $allMails = $this->mailer->findEmails($to, $from);


### PR DESCRIPTION
Follows same logic as thereIsAnEmailTitled() which sets the $to param of findEmail() to an empty string