### PR TITLE
Selenium2Driver screenshot functionality

### DIFF
--- a/src/Utility/DebugTools.php
+++ b/src/Utility/DebugTools.php
@@ -133,10 +133,6 @@ trait DebugTools
     {
         // Validate driver
         $driver = $this->getSession()->getDriver();
-        if (!($driver instanceof FacebookWebDriver)) {
-            $this->logMessage('ScreenShots are only supported for FacebookWebDriver: skipping');
-            return;
-        }
         $feature = $event->getFeature();
         $step = $event->getStep();
         $path = $this->prepareScreenshotPath();


### PR DESCRIPTION
The getScreenshot() function has been included in Selenium2Driver since the v1.0.3 tag (current tag v1.6.0) so the FacebookWebDriver instance check should no longer be required

https://github.com/minkphp/MinkSelenium2Driver/blob/5d27505f991763d1392030f99556debcba1abf2d/src/Selenium2Driver.php#L488