### PR TITLE
API Use class from new template engine module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "behat/mink": "^1.10.0",
         "friends-of-behat/mink-extension": "^2",
         "silverstripe/mink-facebook-web-driver": "^2",
+        "silverstripe/template-engine": "^1",
         "symfony/dom-crawler": "^7.0",
         "silverstripe/testsession": "^4",
         "silverstripe/framework": "^6",

--- a/src/Controllers/ModuleInitialisationController.php
+++ b/src/Controllers/ModuleInitialisationController.php
@@ -15,7 +15,7 @@ use Behat\Testwork\Suite\SuiteRepository;
 use Exception;
 use SilverStripe\Core\Manifest\Module;
 use SilverStripe\Model\ArrayData;
-use SilverStripe\View\SSTemplateEngine;
+use SilverStripe\TemplateEngine\SSTemplateEngine;
 use SilverStripe\View\ViewLayerData;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;


### PR DESCRIPTION
The template engine code is in its own module now, so we need to add it as a dependency and update the use statement. Going with `API` since that feels like it takes precedence over `DEP` and updating a `use` statement feels like a `API` commit to me, but I'm happy to change the prefix if the reviewer wants me to.


CI for this can't go green until https://github.com/silverstripe/silverstripe-framework/pull/11451 has been merged

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11322