### PR TITLE
ENH Remove code that had been retained for backwards compatibility

### DIFF
--- a/src/Context/BasicContext.php
+++ b/src/Context/BasicContext.php
@@ -1332,11 +1332,6 @@ JS;
      */
     public function iShouldSeeTheElement($not, $cssSelector = '')
     {
-        // backwards compatibility for when function signature was just ($cssSelector)
-        if (!in_array($not, ['', ' not'])) {
-            $not = '';
-            $cssSelector = $not;
-        }
         $sel = str_replace('"', '\\"', $cssSelector ?? '');
         $js = <<<JS
 return document.querySelector("$sel");


### PR DESCRIPTION
The only way that code would be triggered is if someone is calling this method _directly_ rather than via a behat feature, which is extremely unlikely.

## Issue
- https://github.com/silverstripe/.github/issues/311