### PR TITLE
MNT Do not set unit-test locale to US

### DIFF
--- a/tests/php/SilverStripeContextTest.php
+++ b/tests/php/SilverStripeContextTest.php
@@ -17,6 +17,8 @@ class SilverStripeContextTest extends SapphireTest
 
     protected $backupGlobals = false;
 
+    protected bool $doSetSupportedModuleLocaleToUS = false;
+
     public function testGetRegionObjThrowsExceptionOnUnknownSelector()
     {
         $this->expectException(\LogicException::class);


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/357

Requires https://github.com/silverstripe/silverstripe-framework/pull/11576

[Kitchen sink CI run](https://github.com/creative-commoners/recipe-kitchen-sink/actions/runs/12979001917) with this [PR](https://github.com/silverstripe/silverstripe-framework/pull/11576) - https://github.com/creative-commoners/recipe-kitchen-sink/actions/runs/12979001917