### PR TITLE
ENH Allow setting `base_url` in the `behat.yml` file.

### DIFF
--- a/src/Compiler/MinkExtensionBaseUrlPass.php
+++ b/src/Compiler/MinkExtensionBaseUrlPass.php
@@ -17,12 +17,17 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 class MinkExtensionBaseUrlPass implements CompilerPassInterface
 {
     /**
-     * Passes MinkExtension's base_url parameter
+     * Passes MinkExtension's base_url parameter from environment variables if missing in behat.yml
      *
      * @param ContainerBuilder $container
      */
     public function process(ContainerBuilder $container)
     {
+        // If base_url is set in behat.yml, we can just use that.
+        $baseUrl = $container->getParameter('mink.base_url');
+        if ($baseUrl) {
+            return;
+        }
         // Set url from environment
         $baseURL = Environment::getEnv('SS_BASE_URL');
         if (!$baseURL) {


### PR DESCRIPTION
This allows for example a `https` URL in `SS_BASE_URL` for CLI or anything else that needs it, while still using `http` for behat (which is easier to work with I've found)

## Issues

- https://github.com/silverstripe/silverstripe-behat-extension/issues/313